### PR TITLE
Update node-graphql example

### DIFF
--- a/node-graphql/README.md
+++ b/node-graphql/README.md
@@ -7,9 +7,9 @@ This example demonstrates how to implement a **GraphQL server with JavaScript** 
 ### 1. Install the Prisma CLI
 
 ```
-yarn global add prisma
+yarn global add prisma@beta
 # or
-npm install -g prisma
+npm install -g prisma@beta
 ```
 
 ### 2. Download example & Install dependencies
@@ -34,9 +34,9 @@ You will now deploy the Prisma API that's backing this example. This requires yo
 ```
 docker-compose up -d
 
-cd primsa
+cd prisma
 
-yarn prisma deploy
+prisma deploy
 ```
 
 <details>
@@ -46,7 +46,7 @@ To deploy your service to a Demo server (rather than locally with Docker), follo
 
 - Run the following command:
   ```
-  yarn prisma deploy --new
+  prisma deploy --new
   ```
 - In the interactive CLI wizard:
   - Select the **Demo server**


### PR DESCRIPTION
The instructions in the README had several problems.

1) `prisma@1.16.x` does not know `generate`. So when running `prisma deploy` with the existing `prisma.yml`, I receive this error message:

>  ▸    prisma.yml should NOT have additional properties. additionalProperty: generate

Hence, I updated the guide to refer to `prisma@beta` instead.

2) Guide instructs to install global `prisma`, but then uses local `prisma` to deploy - this is inconsistent and I chose the global version for the next reason.

3) When running 
```
cd prisma
yarn prisma deploy
```
I get the error message:

>  ▸    Couldn’t find `prisma.yml` file. Are you in the right directory?

This is because the working directory of `yarn prisma deploy` is `./` whereas `prisma.yml` is in `./prisma/prisma.yml`. Some notes:
* This is resolved by 2) already
* a `.graphqlconfig.yml` file could be added in `./` that uses the `graphql-config-extension-prisma` to point to `./prisma/prisma.yml` to resolve this
* we could change the `prisma` script in `package.json` script to `cd prisma && yarn prisma deploy`, however this breaks on shells that are not compatible with `&&` (e.g. `fish`)

4) there was a typo #primsa

I assume those inconsistencies to exist in other examples as well.