### PR TITLE
fix(go): regenerate after error fix

### DIFF
--- a/go-graphql/Gopkg.lock
+++ b/go-graphql/Gopkg.lock
@@ -67,6 +67,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:e4b889a2efa063e446dc2cca35dbe2484c47bbe1f2c5c20b8d043c6e6b3009c3"
+  name = "github.com/prisma/prisma-client-lib-go"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "886b6a49a2294d77aa3e9cee412aba20987d3488"
+
+[[projects]]
+  branch = "master"
   digest = "1:8150271279cc160a41e9aabfee8118c20a0e88894a25b2577f93e7c868e5259c"
   name = "github.com/vektah/gqlparser"
   packages = [
@@ -89,7 +97,7 @@
     "github.com/99designs/gqlgen/graphql/introspection",
     "github.com/99designs/gqlgen/handler",
     "github.com/machinebox/graphql",
-    "github.com/mitchellh/mapstructure",
+    "github.com/prisma/prisma-client-lib-go",
     "github.com/vektah/gqlparser",
     "github.com/vektah/gqlparser/ast",
   ]

--- a/go-graphql/prisma-client/prisma.go
+++ b/go-graphql/prisma-client/prisma.go
@@ -56,7 +56,7 @@ func (client *Client) GraphQL(ctx context.Context, query string, variables map[s
 	return client.Client.GraphQL(ctx, query, variables)
 }
 
-var DefaultEndpoint = "`http://localhost:4466/go-graphql/dev`"
+var DefaultEndpoint = "http://localhost:4466/go-graphql/dev"
 
 func (client *Client) Post(params PostWhereUniqueInput) *PostExec {
 	ret := client.Client.GetOne(

--- a/go-graphql/prisma-client/prisma.go
+++ b/go-graphql/prisma-client/prisma.go
@@ -4,11 +4,14 @@ package prisma
 
 import (
 	"context"
+	"errors"
 
 	"github.com/prisma/prisma-client-lib-go"
 
 	"github.com/machinebox/graphql"
 )
+
+var ErrNoResult = errors.New("query returned no result")
 
 func Str(v string) *string { return &v }
 func Int32(v int32) *int32 { return &v }
@@ -617,10 +620,16 @@ type UserPreviousValuesExec struct {
 	exec *prisma.Exec
 }
 
-func (instance UserPreviousValuesExec) Exec(ctx context.Context) (UserPreviousValues, error) {
+func (instance UserPreviousValuesExec) Exec(ctx context.Context) (*UserPreviousValues, error) {
 	var v UserPreviousValues
-	err := instance.exec.Exec(ctx, &v)
-	return v, err
+	ok, err := instance.exec.Exec(ctx, &v)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNoResult
+	}
+	return &v, nil
 }
 
 func (instance UserPreviousValuesExec) Exists(ctx context.Context) (bool, error) {
@@ -658,10 +667,16 @@ func (instance *PostEdgeExec) Node() *PostExec {
 	return &PostExec{ret}
 }
 
-func (instance PostEdgeExec) Exec(ctx context.Context) (PostEdge, error) {
+func (instance PostEdgeExec) Exec(ctx context.Context) (*PostEdge, error) {
 	var v PostEdge
-	err := instance.exec.Exec(ctx, &v)
-	return v, err
+	ok, err := instance.exec.Exec(ctx, &v)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNoResult
+	}
+	return &v, nil
 }
 
 func (instance PostEdgeExec) Exists(ctx context.Context) (bool, error) {
@@ -720,10 +735,16 @@ func (instance *UserExec) Posts(params *PostsParamsExec) *PostExecArray {
 	return &PostExecArray{ret}
 }
 
-func (instance UserExec) Exec(ctx context.Context) (User, error) {
+func (instance UserExec) Exec(ctx context.Context) (*User, error) {
 	var v User
-	err := instance.exec.Exec(ctx, &v)
-	return v, err
+	ok, err := instance.exec.Exec(ctx, &v)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNoResult
+	}
+	return &v, nil
 }
 
 func (instance UserExec) Exists(ctx context.Context) (bool, error) {
@@ -750,10 +771,16 @@ type PageInfoExec struct {
 	exec *prisma.Exec
 }
 
-func (instance PageInfoExec) Exec(ctx context.Context) (PageInfo, error) {
+func (instance PageInfoExec) Exec(ctx context.Context) (*PageInfo, error) {
 	var v PageInfo
-	err := instance.exec.Exec(ctx, &v)
-	return v, err
+	ok, err := instance.exec.Exec(ctx, &v)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNoResult
+	}
+	return &v, nil
 }
 
 func (instance PageInfoExec) Exists(ctx context.Context) (bool, error) {
@@ -812,14 +839,20 @@ func (instance *PostConnectionExec) Aggregate(ctx context.Context) (Aggregate, e
 		[]string{"count"})
 
 	var v Aggregate
-	err := ret.Exec(ctx, &v)
+	_, err := ret.Exec(ctx, &v)
 	return v, err
 }
 
-func (instance PostConnectionExec) Exec(ctx context.Context) (PostConnection, error) {
+func (instance PostConnectionExec) Exec(ctx context.Context) (*PostConnection, error) {
 	var v PostConnection
-	err := instance.exec.Exec(ctx, &v)
-	return v, err
+	ok, err := instance.exec.Exec(ctx, &v)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNoResult
+	}
+	return &v, nil
 }
 
 func (instance PostConnectionExec) Exists(ctx context.Context) (bool, error) {
@@ -854,10 +887,16 @@ func (instance *PostExec) Author() *UserExec {
 	return &UserExec{ret}
 }
 
-func (instance PostExec) Exec(ctx context.Context) (Post, error) {
+func (instance PostExec) Exec(ctx context.Context) (*Post, error) {
 	var v Post
-	err := instance.exec.Exec(ctx, &v)
-	return v, err
+	ok, err := instance.exec.Exec(ctx, &v)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNoResult
+	}
+	return &v, nil
 }
 
 func (instance PostExec) Exists(ctx context.Context) (bool, error) {
@@ -909,10 +948,16 @@ func (instance *PostSubscriptionPayloadExec) PreviousValues() *PostPreviousValue
 	return &PostPreviousValuesExec{ret}
 }
 
-func (instance PostSubscriptionPayloadExec) Exec(ctx context.Context) (PostSubscriptionPayload, error) {
+func (instance PostSubscriptionPayloadExec) Exec(ctx context.Context) (*PostSubscriptionPayload, error) {
 	var v PostSubscriptionPayload
-	err := instance.exec.Exec(ctx, &v)
-	return v, err
+	ok, err := instance.exec.Exec(ctx, &v)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNoResult
+	}
+	return &v, nil
 }
 
 func (instance PostSubscriptionPayloadExec) Exists(ctx context.Context) (bool, error) {
@@ -948,10 +993,16 @@ func (instance *UserEdgeExec) Node() *UserExec {
 	return &UserExec{ret}
 }
 
-func (instance UserEdgeExec) Exec(ctx context.Context) (UserEdge, error) {
+func (instance UserEdgeExec) Exec(ctx context.Context) (*UserEdge, error) {
 	var v UserEdge
-	err := instance.exec.Exec(ctx, &v)
-	return v, err
+	ok, err := instance.exec.Exec(ctx, &v)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNoResult
+	}
+	return &v, nil
 }
 
 func (instance UserEdgeExec) Exists(ctx context.Context) (bool, error) {
@@ -976,10 +1027,16 @@ type PostPreviousValuesExec struct {
 	exec *prisma.Exec
 }
 
-func (instance PostPreviousValuesExec) Exec(ctx context.Context) (PostPreviousValues, error) {
+func (instance PostPreviousValuesExec) Exec(ctx context.Context) (*PostPreviousValues, error) {
 	var v PostPreviousValues
-	err := instance.exec.Exec(ctx, &v)
-	return v, err
+	ok, err := instance.exec.Exec(ctx, &v)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNoResult
+	}
+	return &v, nil
 }
 
 func (instance PostPreviousValuesExec) Exists(ctx context.Context) (bool, error) {
@@ -1031,10 +1088,16 @@ func (instance *UserSubscriptionPayloadExec) PreviousValues() *UserPreviousValue
 	return &UserPreviousValuesExec{ret}
 }
 
-func (instance UserSubscriptionPayloadExec) Exec(ctx context.Context) (UserSubscriptionPayload, error) {
+func (instance UserSubscriptionPayloadExec) Exec(ctx context.Context) (*UserSubscriptionPayload, error) {
 	var v UserSubscriptionPayload
-	err := instance.exec.Exec(ctx, &v)
-	return v, err
+	ok, err := instance.exec.Exec(ctx, &v)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNoResult
+	}
+	return &v, nil
 }
 
 func (instance UserSubscriptionPayloadExec) Exists(ctx context.Context) (bool, error) {
@@ -1090,14 +1153,20 @@ func (instance *UserConnectionExec) Aggregate(ctx context.Context) (Aggregate, e
 		[]string{"count"})
 
 	var v Aggregate
-	err := ret.Exec(ctx, &v)
+	_, err := ret.Exec(ctx, &v)
 	return v, err
 }
 
-func (instance UserConnectionExec) Exec(ctx context.Context) (UserConnection, error) {
+func (instance UserConnectionExec) Exec(ctx context.Context) (*UserConnection, error) {
 	var v UserConnection
-	err := instance.exec.Exec(ctx, &v)
-	return v, err
+	ok, err := instance.exec.Exec(ctx, &v)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNoResult
+	}
+	return &v, nil
 }
 
 func (instance UserConnectionExec) Exists(ctx context.Context) (bool, error) {

--- a/go-graphql/server/resolver.go
+++ b/go-graphql/server/resolver.go
@@ -28,31 +28,31 @@ func (r *Resolver) User() UserResolver {
 type mutationResolver struct{ *Resolver }
 
 func (r *mutationResolver) CreateDraft(ctx context.Context, title string, content string, authorEmail string) (prisma.Post, error) {
-	return r.Prisma.CreatePost(prisma.PostCreateInput{
+	post, err := r.Prisma.CreatePost(prisma.PostCreateInput{
 		Title:   title,
 		Content: content,
 		Author: prisma.UserCreateOneWithoutPostsInput{
 			Connect: &prisma.UserWhereUniqueInput{Email: &authorEmail},
 		},
 	}).Exec(ctx)
+	return *post, err
 }
 func (r *mutationResolver) DeletePost(ctx context.Context, id string) (*prisma.Post, error) {
-	post, err := r.Prisma.DeletePost(prisma.PostWhereUniqueInput{ID: &id}).Exec(ctx)
-	return &post, err
+	return r.Prisma.DeletePost(prisma.PostWhereUniqueInput{ID: &id}).Exec(ctx)
 }
 func (r *mutationResolver) Publish(ctx context.Context, id string) (*prisma.Post, error) {
 	isPublished := true
-	post, err := r.Prisma.UpdatePost(prisma.PostUpdateParams{
+	return r.Prisma.UpdatePost(prisma.PostUpdateParams{
 		Where: prisma.PostWhereUniqueInput{ID: &id},
 		Data:  prisma.PostUpdateInput{IsPublished: &isPublished},
 	}).Exec(ctx)
-	return &post, err
 }
 
 type postResolver struct{ *Resolver }
 
 func (r *postResolver) Author(ctx context.Context, obj *prisma.Post) (prisma.User, error) {
-	return r.Prisma.Post(prisma.PostWhereUniqueInput{ID: &obj.ID}).Author().Exec(ctx)
+	author, err := r.Prisma.Post(prisma.PostWhereUniqueInput{ID: &obj.ID}).Author().Exec(ctx)
+	return *author, err
 }
 
 type queryResolver struct{ *Resolver }
@@ -70,8 +70,7 @@ func (r *queryResolver) Drafts(ctx context.Context) ([]prisma.Post, error) {
 	}).Exec(ctx)
 }
 func (r *queryResolver) Post(ctx context.Context, id string) (*prisma.Post, error) {
-	post, err := r.Prisma.Post(prisma.PostWhereUniqueInput{ID: &id}).Exec(ctx)
-	return &post, err
+	return r.Prisma.Post(prisma.PostWhereUniqueInput{ID: &id}).Exec(ctx)
 }
 
 type userResolver struct{ *Resolver }


### PR DESCRIPTION
To note are `CreateDraft` and `Author` resolvers. The front schema does not match the Prisma schema in these cases in terms of return types and hence, a direct return does not work but we need to pluck them in a variable and use pointer dereferencing. 