### PR TITLE
make examples self-contained

### DIFF
--- a/typescript/graphql-auth/package.json
+++ b/typescript/graphql-auth/package.json
@@ -3,8 +3,17 @@
   "license": "MIT",
   "scripts": {
     "start": "ts-node-dev --no-notify --respawn --transpileOnly ./src",
+    "postinstall": "yarn generate",
+    "clean": "yarn clean:db && yarn clean:migrations",
+    "clean:db": "rimraf prisma/dev.db",
+    "clean:migrations": "rimraf prisma/migrations",
+    "lift": "yarn lift:save && yarn lift:up",
+    "lift:save": "yarn prisma2 lift save -n init",
+    "lift:up": "yarn prisma2 lift up",
     "seed": "ts-node prisma/seed.ts",
-    "postinstall": "prisma2 generate"
+    "generate": "yarn generate:prisma && yarn generate:nexus",
+    "generate:prisma": "prisma2 generate",
+    "generate:nexus": "echo 'todo'"
   },
   "dependencies": {
     "bcrypt": "3.0.6",
@@ -17,9 +26,10 @@
     "@types/bcrypt": "3.0.0",
     "@types/jsonwebtoken": "8.3.3",
     "@types/node": "12.7.3",
+    "prisma2": "2.0.0-preview-9.1",
+    "rimraf": "3.0.0",
     "ts-node": "8.3.0",
     "ts-node-dev": "1.0.0-pre.42",
-    "typescript": "3.6.2",
-    "prisma2": "2.0.0-preview-9.1"
+    "typescript": "3.6.2"
   }
 }


### PR DESCRIPTION
I fiddled around with prisma2 this weekend and so far I'm loving it, even though it was quite the wonky ride.

`prisma2 init` failed in many scenarios. Either one of the init flows couldn't finish or the initialized example didn't work as intended out of the box.

So I followed the [tutorial](https://github.com/prisma/prisma2/blob/master/docs/tutorial.md) from the `prisma2` repo but failed as soon as trying to set up GraphQL with Nexus.

My guess was that `prisma2 init` cloned the [`photonjs/examples`](https://github.com/prisma/photonjs/tree/master/examples) but yesterday I didn't manage to successfully make any of those work. The only working example I found was [`nexus-prisma/example`](https://github.com/prisma/nexus-prisma/tree/next/example) repo.

Thanks to your efforts above issues were resolved by fixing [#367](https://github.com/prisma/nexus-prisma/issues/367), updating the examples and moving them here. I guess it was just unlucky that the examples didn't work with my globally installed `nexus2` version.

Making the examples self contained would have prevented this from happening. Why not harness the power of using prisma2 as a `devDependency`?

So far I have only looked at the `graphql-auth` example but I'm pleased to see that the dependencies in `package.json` are `--exact` and `prisma2` was added as a `devDependency`, so that example works fine for me now.

A couple of things that still bother me:

1. The `graphql-auth` example requires `yarn global add nexus2` which causes users running into issues like [#367](https://github.com/prisma/nexus-prisma/issues/367). Removing `nexus2` as a global dependency solves that. What I don't know for a fact is if these examples are tightly coupled to the `prisma2 init` flows. I can understand why the CLI tooling should be installed globally but much like `@angular/cli`, I prefer to install it as a `devDependency` and add aliases via `package.json`. I also have `prisma2` installed globally but right now its just not convenient enough without aliases like `p lift up` or `p generate`.
2. The `graphql-auth` example requires the user to run `yarn install`, `prisma2 lift save -n init`, `prisma2 lift up`, `yarn seed` and then _finally_ `yarn start`. I don't know if this example is supposed to showcase the entire toolchain or has to work with `prisma2 init`. For me, as a beginner, I just wanted to run and explore the example without doing anything.

Once you understand the `prisma2` toolchain these steps seem simple enough but when just starting out and running into issues like [#367](https://github.com/prisma/nexus-prisma/issues/367) it can be quite frustrating.

My changes are inspired by [`nexus-prisma/example/package.json`](https://github.com/prisma/nexus-prisma/tree/next/example/package.json) that leverages "convenient yarn aliases" independent of the globally installed `prisma2` CLI tooling.

This is pretty much how I use it right now but not everyone uses yarn. It would also be much simpler, if you wouldn't `.gitignore` `migrations/` and just add a migrated and seeded `dev.db` binary. This would eliminate the `clean`, `lift` and `seed` part of my proposed changes inside `package.json` and much of the steps inside `README.md`.

This way, the `postinstall` script would also make more sense. Right now, when cloning the repo and running `yarn install` for the _first time,_ `photon` and `nexus` clients are generated. For new users that's just confusing and might give the illusion of having a working example when in reality `dev.db` and `migrations/` are in an invalid state.

IMO this example should showcase graphql and authentication, so the focus should be on `"generate:nexus": "echo 'todo'"` and not having to worry about `lift` and `photon`.

I haven't checked out yet if anything related is going on the `fix/nexus-prisma-examples` branch.

Would be glad to help out!