### PR TITLE
Fix an old reference to the start command in README

### DIFF
--- a/typescript/graphql/README.md
+++ b/typescript/graphql/README.md
@@ -226,7 +226,7 @@ mutation {
 
 To make changes to the GraphQL schema, you need to manipulate the `Query` and `Mutation` types that are defined in [`index.ts`](./src/index.ts). 
 
-Note that the [`start`](./package.json#L4) script also starts a development server that automatically updates your schema every time you save a file. This way, the auto-generated [GraphQL schema](./src/schema.graphql) updates whenever you make changes in to the `Query` or `Mutation` types inside your TypeScript code.
+Note that [`npm run dev`](./package.json#L4) also starts a development server that automatically updates your schema every time you save a file. This way, the auto-generated [GraphQL schema](./src/schema.graphql) updates whenever you make changes in to the `Query` or `Mutation` types inside your TypeScript code.
 
 
 ## Next steps


### PR DESCRIPTION
I updated the name of the command to start a server and to disambiguate it from `prisma2 dev` I wrote the whole command `npm run dev`.