### PR TITLE
Fix broken link

### DIFF
--- a/deployment-platforms/codesandbox/README.md
+++ b/deployment-platforms/codesandbox/README.md
@@ -7,7 +7,7 @@ This example shows how to use the Prisma client in a **Codesandbox container** t
 ### 1. Create a new Codesandbox by importing a GitHub repository and point it to this folder.
 
 ```
-https://github.com/prisma/photonjs/tree/master/examples/typescript/codesandbox
+https://github.com/prisma/prisma-examples/tree/prisma2/deployment-platforms/codesandbox
 ```
 
 ### 2. Codesandbox automatically runs the `start` script


### PR DESCRIPTION
The instructions will fail because https://github.com/prisma/photonjs/tree/master/examples/typescript/codesandbox does not exist anymore. Potentially it might even be better to provide a direct link to codesandbox (https://codesandbox.io/s/github/prisma/prisma-examples/tree/prisma2/deployment-platforms/codesandbox)