### PR TITLE
Set NODE_ENV to 'production' in 'netlify.toml'

### DIFF
--- a/deployment-platforms/netlify/netlify.toml
+++ b/deployment-platforms/netlify/netlify.toml
@@ -1,2 +1,5 @@
 [build]
 functions = "functions/"
+
+[build.environment]
+NODE_ENV = "production"


### PR DESCRIPTION
I was having issues with setting up Netlify Functions, when I realized that environment variables shall be configured prior to deployment. By adding these lines, the environment will be set to `'production'` out of the box.