### PR TITLE
Updating README references for schema and auto-generated schema

### DIFF
--- a/typescript/graphql/README.md
+++ b/typescript/graphql/README.md
@@ -103,7 +103,7 @@ Navigate to [http://localhost:4000](http://localhost:4000) in your browser to ex
 
 ### 5. Using the GraphQL API
 
-The schema that specifies the API operations of your GraphQL server is defined in [`./src/schema.graphql`](./src/schema.graphql). Below are a number of operations that you can send to the API using the GraphQL Playground.
+The schema that specifies the API operations of your GraphQL server is defined in [`./src/schema.ts`](./src/schema.ts). Below are a number of operations that you can send to the API using the GraphQL Playground.
 
 Feel free to adjust any operation by adding or removing fields. The GraphQL Playground helps you with its auto-completion and query validation features.
 
@@ -228,7 +228,7 @@ mutation {
 
 To make changes to the GraphQL schema, you need to manipulate the `Query` and `Mutation` types that are defined in [`schema.ts`](./src/schema.ts). 
 
-Note that the [`dev`](./package.json#L4) script also starts a development server that automatically updates your schema every time you save a file. This way, the auto-generated [GraphQL schema](./src/schema.graphql) updates whenever you make changes in to the `Query` or `Mutation` types inside your TypeScript code.
+Note that the [`dev`](./package.json#L4) script also starts a development server that automatically updates your schema every time you save a file. This way, the auto-generated [GraphQL schema](./src/generated/schema.graphql) updates whenever you make changes in to the `Query` or `Mutation` types inside your TypeScript code.
 
 
 ## Next steps


### PR DESCRIPTION
A location got updated and a file extension renamed, so the references were broken