### PR TITLE
Update TypeGraphQL domain in READMEs

### DIFF
--- a/.github/readmes/typescript/graphql-typegraphql/README.md
+++ b/.github/readmes/typescript/graphql-typegraphql/README.md
@@ -1,6 +1,6 @@
 # GraphQL Server Example
 
-This example shows how to use the **TypeGraphQL library** to **implement a GraphQL server with TypeScript** based on [Prisma Client](https://github.com/prisma/prisma2/blob/master/docs/prisma-client-js/api.md), [graphql-yoga](https://github.com/prisma/graphql-yoga) and [TypeGraphQL](https://typegraphql.ml/). It is based on a SQLite database - you can find the database file with some dummy data at [`./prisma/dev.db`](./prisma/dev.db).
+This example shows how to use the **TypeGraphQL library** to **implement a GraphQL server with TypeScript** based on [Prisma Client](https://github.com/prisma/prisma2/blob/master/docs/prisma-client-js/api.md), [graphql-yoga](https://github.com/prisma/graphql-yoga) and [TypeGraphQL](https://typegraphql.com/). It is based on a SQLite database - you can find the database file with some dummy data at [`./prisma/dev.db`](./prisma/dev.db).
 
 __INLINE(../_setup-1.md)__
 cd prisma-examples/typescript/graphql-typegraphql

--- a/typescript/graphql-typegraphql/README.md
+++ b/typescript/graphql-typegraphql/README.md
@@ -1,6 +1,6 @@
 # GraphQL Server Example
 
-This example shows how to use the **TypeGraphQL library** to **implement a GraphQL server with TypeScript** based on [Prisma Client](https://github.com/prisma/prisma2/blob/master/docs/prisma-client-js/api.md), [graphql-yoga](https://github.com/prisma/graphql-yoga) and [TypeGraphQL](https://typegraphql.ml/). It is based on a SQLite database - you can find the database file with some dummy data at [`./prisma/dev.db`](./prisma/dev.db).
+This example shows how to use the **TypeGraphQL library** to **implement a GraphQL server with TypeScript** based on [Prisma Client](https://github.com/prisma/prisma2/blob/master/docs/prisma-client-js/api.md), [graphql-yoga](https://github.com/prisma/graphql-yoga) and [TypeGraphQL](https://typegraphql.com/). It is based on a SQLite database - you can find the database file with some dummy data at [`./prisma/dev.db`](./prisma/dev.db).
 
 ## How to use
 


### PR DESCRIPTION
The domain has changed a few weeks ago from `typegraphql.ml` to `typegraphql.com`