### PR TITLE
Fix searchString missing type

### DIFF
--- a/typescript/rest-express/src/index.ts
+++ b/typescript/rest-express/src/index.ts
@@ -67,7 +67,7 @@ app.get('/feed', async (req, res) => {
 })
 
 app.get('/filterPosts', async (req, res) => {
-  const { searchString } = req.query
+  const { searchString }: { searchString?: string } = req.query;
   const draftPosts = await prisma.post.findMany({
     where: {
       OR: [


### PR DESCRIPTION
This fix the typescript error:

Type 'Query' is not assignable to type 'string'.

Detail:
src/index.ts:76:13 - error TS2322: Type 'string | Query | string[] | Query[]' is not assignable to type 'string | null | undefined'.
  Type 'Query' is not assignable to type 'string'.

76             contains: searchString,
               ~~~~~~~~
src/index.ts:81:13 - error TS2322: Type 'string | Query | string[] | Query[]' is not assignable to type 'string | null | undefined'.
  Type 'Query' is not assignable to type 'string'.

81             contains: searchString,
               ~~~~~~~~

`contains: <string>searchString` or `contains: searchString as string` are also possible solutions but less cleaner.