### PR TITLE
Implement workaround for `npm run generate:nexus` (cf. #1763)

### DIFF
--- a/typescript/graphql-nextjs/nexus.tsconfig.json
+++ b/typescript/graphql-nextjs/nexus.tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "outDir": "dist",
+    "strict": true,
+    "lib": ["esnext"],
+    "esModuleInterop": true
+  }
+}

--- a/typescript/graphql-nextjs/nexus.tsconfig.json
+++ b/typescript/graphql-nextjs/nexus.tsconfig.json
@@ -1,4 +1,8 @@
 {
+  /* 
+    This file is used as a workaround for https://github.com/graphql-nexus/schema/issues/391
+    It allows the nexus schema generation to work (done via `npm run generate:nexus`).
+  */
   "compilerOptions": {
     "sourceMap": true,
     "outDir": "dist",

--- a/typescript/graphql-nextjs/package.json
+++ b/typescript/graphql-nextjs/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "generate": "npm -s run generate:prisma && npm -s run generate:nexus",
     "generate:prisma": "prisma generate",
-    "generate:nexus": "ts-node --transpile-only pages/api"
+    "generate:nexus": "ts-node --transpile-only -P nexus.tsconfig.json pages/api"
   },
   "keywords": [],
   "author": "",

--- a/typescript/graphql-nextjs/tsconfig.json
+++ b/typescript/graphql-nextjs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "esnext",
     "target": "ES2019",
     "lib": [
       "dom",

--- a/typescript/graphql-nextjs/tsconfig.json
+++ b/typescript/graphql-nextjs/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "compilerOptions": {
+    /* 
+      Note that the "module" setting will be overriden by nextjs automatically
+      (cf. https://github.com/zeit/next.js/discussions/10780).
+      If you need to change it, you should use the --compiler-options or provide a separate 
+      tsconfig.json entirely.
+    */
     "module": "esnext",
     "target": "ES2019",
     "lib": [


### PR DESCRIPTION
This PR proposes to implement a workaround for #1763 to allow regenerating the nexus schema until the related [nexus issue](https://github.com/graphql-nexus/schema/issues/391) and/or the [nextjs issue](https://github.com/zeit/next.js/discussions/10780) are solved.
