### PR TITLE
improve(workflows): rename workflows to clearer names

### DIFF
--- a/.github/workflows/keep-alpha-branch-in-sync-with-master.yaml
+++ b/.github/workflows/keep-alpha-branch-in-sync-with-master.yaml
@@ -1,4 +1,4 @@
-name: sync-alpha
+name: keep-alpha-branch-in-sync-with-master
 on:
   push:
     branches:

--- a/.github/workflows/keep-prisma-dependencies-updated.yaml
+++ b/.github/workflows/keep-prisma-dependencies-updated.yaml
@@ -1,4 +1,4 @@
-name: check-for-update
+name: keep-prisma-dependencies-updated
 on:
   schedule:
     - cron: '*/5 * * * *'

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 <div align="center">
   
   ![test](https://github.com/prisma/prisma-examples/workflows/test/badge.svg)
-  ![check-for-update](https://github.com/prisma/prisma-examples/workflows/check-for-update/badge.svg)
+  ![keep-prisma-dependencies-updated](https://github.com/prisma/prisma-examples/workflows/keep-prisma-dependencies-updated/badge.svg)
   
 </div>
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   
   ![test](https://github.com/prisma/prisma-examples/workflows/test/badge.svg)
   ![keep-prisma-dependencies-updated](https://github.com/prisma/prisma-examples/workflows/keep-prisma-dependencies-updated/badge.svg)
+  ![keep-alpha-branch-in-sync-with-master](https://github.com/prisma/prisma-examples/workflows/keep-alpha-branch-in-sync-with-master/badge.svg)
   
 </div>
 


### PR DESCRIPTION
This renames the `check-for-update` GH Action workflow to `keep-prisma-dependencies-updated`, and `sync-alpha` to `keep-alpha-branch-in-sync-with-master` to better highlight what they and why it is important that they succeed.

(The badge in the README should work again after this is merged and the workflow ran once)