### PR TITLE
docs(README): add gh action badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://www.prisma.io/">Website</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://www.prisma.io/docs/">Docs</a>
-    <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://www.prisma.io/blog">Blog</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://slack.prisma.io/">Slack</a>
@@ -14,6 +14,13 @@
   <a href="https://twitter.com/prisma">Twitter</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://www.youtube.com/watch?v=0RhtQgIs-TE&list=PLn2e1F9Rfr6k9PnR_figWOcSHgc_erDr5&index=1">Demo videos</a>
+</div>
+
+<hr>
+
+<div align="center">
+  ![test](https://github.com/prisma/prisma-examples/workflows/test/badge.svg)
+  ![check-for-update](https://github.com/prisma/prisma-examples/workflows/check-for-update/badge.svg)
 </div>
 
 <hr>

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@
 <hr>
 
 <div align="center">
+  
   ![test](https://github.com/prisma/prisma-examples/workflows/test/badge.svg)
   ![check-for-update](https://github.com/prisma/prisma-examples/workflows/check-for-update/badge.svg)
+  
 </div>
 
 <hr>


### PR DESCRIPTION
This PR adds the two important GH actions as badges to the README to increase visibility into possible failures.

Open for better positioning or styling of course, this is a bit "brute force".