### PR TITLE
ci(keep-prisma-dependencies-updated): rename jobs

### DIFF
--- a/.github/workflows/keep-prisma-dependencies-updated.yaml
+++ b/.github/workflows/keep-prisma-dependencies-updated.yaml
@@ -3,7 +3,7 @@ on:
   schedule:
     - cron: '*/5 * * * *'
 jobs:
-  check-for-preview-update:
+  check-for-update-latest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -13,13 +13,13 @@ jobs:
         with:
           node-version: 10
 
-      - name: check preview update
+      - name: check update latest
         run: sh .github/scripts/check-for-update.sh latest master
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
 
-  check-for-dev-update:
+  check-for-update-dev:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -29,13 +29,13 @@ jobs:
         with:
           node-version: 10
 
-      - name: check dev update
+      - name: check update dev
         run: sh .github/scripts/check-for-update.sh dev dev
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
 
-  check-for-patch-dev-update:
+  check-for-update-patch-dev:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -45,7 +45,7 @@ jobs:
         with:
           node-version: 10
 
-      - name: check patch-dev update
+      - name: check update patch-dev
         run: sh .github/scripts/check-for-update.sh patch-dev patch-dev
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
@@ -53,7 +53,7 @@ jobs:
 
   report-to-slack-failure:
     runs-on: ubuntu-latest
-    needs: [check-for-preview-update, check-for-dev-update]
+    needs: [check-for-update-latest,  check-for-update-dev,  check-for-update-patch-dev]
     if: failure()
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
and add patch-dev as needs for slack failure report as well