### PR TITLE
Remove the introspected schema from the example

### DIFF
--- a/deployment-platforms/vercel/prisma/schema.prisma
+++ b/deployment-platforms/vercel/prisma/schema.prisma
@@ -7,25 +7,3 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model Post {
-  post_id   Int     @default(autoincrement()) @id
-  author_id Int?
-  content   String?
-  title     String
-  author    User?   @relation(fields: [author_id], references: [user_id]) // renamed from `User` -> `author`
-}
-
-model Profile {
-  bio        String?
-  profile_id Int     @default(autoincrement()) @id
-  user_id    Int
-  user       User    @relation(fields: [user_id], references: [user_id]) // renamed from `User` -> `user`
-}
-
-model User {
-  email    String    @unique
-  name     String?
-  user_id  Int       @default(autoincrement()) @id
-  posts    Post[] // renamed from `Post` -> `posts`
-  profiles Profile[] // renamed from `User` -> `profiles`
-}


### PR DESCRIPTION
Since the schema will be filled by introspection, having it in the repository is not necessary. Moreover, in the [deployment guide](https://www.prisma.io/docs/guides/deployment/deploying-to-vercel#5-introspect-the-database), the checkpoint relies on the user successfully introspecting the database, so having it already there can confuse users.