### PR TITLE
ci: tests as matrix

### DIFF
--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -2,6 +2,7 @@
 
 set -eu
 
+item="$1"
 dir="$(pwd)"
 
 

--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -18,7 +18,7 @@ echo "running $item"
 case "$item" in
   *".github"*|*"experimental"*|*"deployment-platforms"*)
     echo "ignoring $item"
-    continue
+    exit 0
     ;;
 esac
 

--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -15,13 +15,6 @@ echo ""
 echo "---------------------"
 echo "running $item"
 
-case "$item" in
-  *".github"*|*"experimental"*|*"deployment-platforms"*)
-    echo "ignoring $item"
-    exit 0
-    ;;
-esac
-
 cd "$(dirname "$item")/"
 
 ## ACTION

--- a/.github/tests/javascript/script/run.sh
+++ b/.github/tests/javascript/script/run.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-set -eu
-
-yarn dev

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Install project and run test
         run: |
-          $item=${{ matrix.path }}
+          $item="${{ matrix.path }}"
           dir="$(pwd)"
           cd "$(dirname "$item")/"
           yarn install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,6 +56,6 @@ jobs:
           version: 12
 
       - name: test
-        run: sh .github/scripts/test.sh ${{ project }}
+        run: sh .github/scripts/test.sh ${{ matrix.project }}
         env:
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -116,8 +116,8 @@ jobs:
 
       - name: Install project and run test
         run: |
-          $item="${{ matrix.path }}"
+          path="${{ matrix.path }}"
           dir="$(pwd)"
-          cd "$(dirname "$item")/"
+          cd "$(dirname "$path")/"
           yarn install
-          $dir/.github/tests/$(dirname "$item")/run.sh"
+          $dir/.github/tests/$(dirname "$path")/run.sh"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,4 +121,5 @@ jobs:
           cd "$(dirname "$path")/"
           yarn install
           run_file="$dir/.github/tests/$(dirname "$item")/run.sh"
-          sh "run_file"
+          echo "$runfile"
+          sh "$run_file"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,9 +6,26 @@ on:
       - dev
       - patch-dev
   pull_request:
+    
 env:
   PRISMA_TELEMETRY_INFORMATION: "prisma-examples test.yaml"
+
 jobs:
+  
+  projects:
+    if: github.repository_owner == 'prisma'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: action/checkout@v2
+        
+      - id: set-matrix
+        run: |
+          packages=$(find "." -not -path "*/node_modules/*" -type f -name "package.json")
+          json=$("$packages" | tr ' ' '\n' | jq -R -c | jq -s)
+          echo "::set-output name=project::$json"
+    
   test:
     if: github.repository_owner == 'prisma'
     runs-on: ubuntu-latest
@@ -28,6 +45,9 @@ jobs:
         ports:
           - '5432:5432'
 
+    strategy:
+      matrix: ${{fromJson(needs.projects.outputs.matrix)}}
+      
     steps:
       - uses: actions/checkout@v2
 
@@ -36,6 +56,6 @@ jobs:
           version: 12
 
       - name: test
-        run: sh .github/scripts/test-all.sh
+        run: sh .github/scripts/test.sh ${{ project }}
         env:
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         
-      - id: set-matrix
+      - name: get list of projects in json array
+        id: set-matrix
         run: |
           # list all package.json files (not in node_modules)
           packages=$(find "." -not -path "*/node_modules/*" -type f -name "package.json")
@@ -29,6 +30,7 @@ jobs:
           json=$(echo "$packages" | tr ' ' '\n' | jq -R -c . | jq -s .)
           # set as variable to be used later
           echo "::set-output name=project::$json"
+          echo $json
     
   test:
     if: github.repository_owner == 'prisma'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
           # turn list into json array
           json1=$(echo "$packages" | tr ' ' '\n' | jq -R -c . | jq -s .)
           # and package into wanted json structure
-          json2=$(echo "{\"include\":$json}")
+          json2=$(echo "{\"include\":$json1}")
           # set as variable to be used later
           echo "::set-output name=matrix::$json2"
           echo $json2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,6 +67,7 @@ jobs:
           - '5432:5432'
 
     strategy:
+      fail-fast: false
       matrix: ${{fromJson(needs.projects.outputs.matrix)}}
       
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,3 +81,43 @@ jobs:
         run: sh .github/scripts/test.sh ${{ matrix.path }}
         env:
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
+
+  test2:
+    needs: projects
+    
+    if: github.repository_owner == 'prisma'
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgis/postgis:12-2.5-alpine
+        env:
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: testing
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - '5432:5432'
+
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.projects.outputs.matrix)}}
+      
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Install project and run test
+        run: |
+          $item=${{ matrix.path }}
+          dir="$(pwd)"
+          cd "$(dirname "$item")/"
+          yarn install
+          $dir/.github/tests/$(dirname "$item")/run.sh"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   
-  # generate json for matrix via https://stackoverflow.com/a/62953566
+  # generate json for matrix, https://github.blog/changelog/2020-04-15-github-actions-new-workflow-features/#new-fromjson-method-in-expressions
   projects:
     if: github.repository_owner == 'prisma'
     runs-on: ubuntu-latest
@@ -29,10 +29,12 @@ jobs:
           # turn list into json array
           json=$(echo "$packages" | tr ' ' '\n' | jq -R -c . | jq -s .)
           # set as variable to be used later
-          echo "::set-output name=project::$json"
+          echo "::set-output name=matrics::{\"include\":$json}"
           echo $json
     
   test:
+    needs: projects
+    
     if: github.repository_owner == 'prisma'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,8 +23,11 @@ jobs:
         
       - id: set-matrix
         run: |
+          # list all package.json files (not in node_modules)
           packages=$(find "." -not -path "*/node_modules/*" -type f -name "package.json")
-          json=$(echo "$packages" | tr ' ' '\n' | jq -R -c)
+          # turn list into json array
+          json=$(echo "$packages" | tr ' ' '\n' | jq -R -c . | jq -s .)
+          # set as variable to be used later
           echo "::set-output name=project::$json"
     
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -120,4 +120,4 @@ jobs:
           dir="$(pwd)"
           cd "$(dirname "$path")/"
           yarn install
-          $dir/.github/tests/$(dirname "$path")/run.sh"
+          sh $dir/.github/tests/$(dirname "$path")/run.sh"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,8 +24,8 @@ jobs:
       - name: get list of projects in json array
         id: set-matrix
         run: |
-          # list all package.json files (not in node_modules)
-          packages=$(find "." -not -path "*/node_modules/*" -type f -name "package.json")
+          # list all package.json files (not in node_modules, experimental, .github or deployment-platforms)
+          packages=$(find "." -not -path "*/node_modules/*" -not -path "*/experimental/*" -not -path "*/deployment-platforms/*" -not -path "*/.github/*" -type f -name "package.json")
           # turn each line into json object
           json1=$(echo "$packages" | tr ' ' '\n' | sed 's/.*/{"path": "&" }/')
           # combine objects into json array

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -120,4 +120,5 @@ jobs:
           dir="$(pwd)"
           cd "$(dirname "$path")/"
           yarn install
-          sh $dir/.github/tests/$(dirname "$path")/run.sh"
+          run_file="$dir/.github/tests/$(dirname "$item")/run.sh"
+          sh "run_file"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -120,6 +120,6 @@ jobs:
           dir="$(pwd)"
           cd "$(dirname "$path")/"
           yarn install
-          run_file="$dir/.github/tests/$(dirname "$item")/run.sh"
+          run_file="$dir/.github/tests/$(dirname "$path")/run.sh"
           echo "$runfile"
           sh "$run_file"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       - id: set-matrix
         run: |
           packages=$(find "." -not -path "*/node_modules/*" -type f -name "package.json")
-          json=$(echo "$packages" | tr ' ' '\n' | jq -R -c | jq -s)
+          json=$(echo "$packages" | tr ' ' '\n') 
           echo "::set-output name=project::$json"
     
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
       - id: set-matrix
         run: |
           packages=$(find "." -not -path "*/node_modules/*" -type f -name "package.json")
-          json=$("$packages" | tr ' ' '\n' | jq -R -c | jq -s)
+          json=$("echo $packages" | tr ' ' '\n' | jq -R -c | jq -s)
           echo "::set-output name=project::$json"
     
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   
+  # generate json for matrix via https://stackoverflow.com/a/62953566
   projects:
     if: github.repository_owner == 'prisma'
     runs-on: ubuntu-latest
@@ -23,7 +24,7 @@ jobs:
       - id: set-matrix
         run: |
           packages=$(find "." -not -path "*/node_modules/*" -type f -name "package.json")
-          json=$("echo $packages" | tr ' ' '\n' | jq -R -c | jq -s)
+          json=$(echo "$packages" | tr ' ' '\n' | jq -R -c | jq -s)
           echo "::set-output name=project::$json"
     
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       - id: set-matrix
         run: |
           packages=$(find "." -not -path "*/node_modules/*" -type f -name "package.json")
-          json=$(echo "$packages" | tr ' ' '\n') 
+          json=$(echo "$packages" | tr ' ' '\n' | jq -R -c)
           echo "::set-output name=project::$json"
     
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
           # turn each line into json object
           json1=$(echo "$packages" | tr ' ' '\n' | sed 's/.*/{"path": "&" }/')
           # combine objects into json array
-          json2=$(echo $json1 | jq -c . | jq -s .)
+          json2=$(echo $json1 | jq -s -c . )
           # and package into wanted json structure
           json3=$(echo "{\"include\":$json2}")
           # set as variable to be used later

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
           # list all package.json files (not in node_modules)
           packages=$(find "." -not -path "*/node_modules/*" -type f -name "package.json")
           # turn list into json array
-          json1=$(echo "$packages" | tr ' ' '\n' | jq -R -c . | jq -s .)
+          json1=$(echo "$packages" | tr ' ' '\n' | sed 's/.*/{"path": "&" }/' | jq -R -c . | jq -s .)
           # and package into wanted json structure
           json2=$(echo "{\"include\":$json1}")
           # set as variable to be used later
@@ -66,6 +66,6 @@ jobs:
           version: 12
 
       - name: test
-        run: sh .github/scripts/test.sh ${{ matrix.project }}
+        run: sh .github/scripts/test.sh ${{ matrix.path }}
         env:
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
           # turn list into json array
           json=$(echo "$packages" | tr ' ' '\n' | jq -R -c . | jq -s .)
           # set as variable to be used later
-          echo "::set-output name=matrics::{\"include\":$json}"
+          echo "::set-output name=matrix::{\"include\":$json}"
           echo $json
     
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: action/checkout@v2
+      - uses: actions/checkout@v2
         
       - id: set-matrix
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,10 +27,12 @@ jobs:
           # list all package.json files (not in node_modules)
           packages=$(find "." -not -path "*/node_modules/*" -type f -name "package.json")
           # turn list into json array
-          json=$(echo "$packages" | tr ' ' '\n' | jq -R -c . | jq -s .)
+          json1=$(echo "$packages" | tr ' ' '\n' | jq -R -c . | jq -s .)
+          # and package into wanted json structure
+          json2=$(echo "{\"include\":$json}")
           # set as variable to be used later
-          echo "::set-output name=matrix::{\"include\":$json}"
-          echo $json
+          echo "::set-output name=matrix::$json2"
+          echo $json2
     
   test:
     needs: projects

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          version: 12
+          node-version: 12
 
       - name: test
         run: sh .github/scripts/test.sh ${{ matrix.path }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,15 @@ jobs:
           echo "::set-output name=matrix::$json3"
           # output for debugging
           echo $json3
-    
+
+  debug:
+    needs: projects
+    runs-on: ubuntu-latest
+    steps:
+      - run: | 
+          echo "${{needs.projects.outputs.matrix}}"
+          echo "${{fromJson(needs.projects.outputs.matrix)}}"
+
   test:
     needs: projects
     

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,13 +26,16 @@ jobs:
         run: |
           # list all package.json files (not in node_modules)
           packages=$(find "." -not -path "*/node_modules/*" -type f -name "package.json")
-          # turn list into json array
-          json1=$(echo "$packages" | tr ' ' '\n' | sed 's/.*/{"path": "&" }/' | jq -R -c . | jq -s .)
+          # turn each line into json object
+          json1=$(echo "$packages" | tr ' ' '\n' | sed 's/.*/{"path": "&" }/')
+          # combine objects into json array
+          json2=$(echo $json1 | jq -c . | jq -s .)
           # and package into wanted json structure
-          json2=$(echo "{\"include\":$json1}")
+          json3=$(echo "{\"include\":$json2}")
           # set as variable to be used later
-          echo "::set-output name=matrix::$json2"
-          echo $json2
+          echo "::set-output name=matrix::$json3"
+          # output for debugging
+          echo $json3
     
   test:
     needs: projects

--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ There are also the automated branches `dev` and `patch-dev`, which mirror the co
 ## Security
 
 If you have a security issue to report, please contact us at [security@prisma.io](mailto:security@prisma.io?subject=[GitHub]%20Prisma%202%20Security%20Report%20Examples)
+


### PR DESCRIPTION
Changes the tests to run via a Matrix that is automatically generated from the existing project folders.

Tasks:
- [x] Generate matrix
- [x] Change Shell script to run for 1 project, not all
- [x] Move skipping of folders from script to matrix generation
- [x] Move more from Shell script into step
- [ ] Slack reporting for step replacing shell script
- [ ] Find better names for jobs

Follow up tasks:
- Put Slack reporting into step as well, similar to https://github.com/prisma/language-tools/blob/0b12cb90720a261ebe540ef4dce8edb7c39982e8/.github/workflows/7_publish.yml#L72-L85