### PR TITLE
fix: slack notifications

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,7 @@ on:
       - patch-dev
   pull_request:
 env:
+  CI: 1
   PRISMA_TELEMETRY_INFORMATION: 'prisma-examples test.yaml'
 jobs:
   test:
@@ -40,3 +41,7 @@ jobs:
         run: sh .github/scripts/test-all.sh
         env:
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
+
+      - name: notify-slack
+        if: failure() && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/patch-dev' || github.ref == 'refs/heads/latest')
+        run: bash .github/scripts/slack-workflow-status.sh ":x:"


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma-examples/issues/2048

There is a notification coming from inside `test-all.sh` and that has the context of which test failed. Since we don't have that context outside, we can't yet remove it from `test-all.sh`

This PR adds a catch-all notification without the name of the actual test that fails (so there may be 2 error messages, for now, one with and one without the actual example name). If that is okay, we can already merge this to not miss errors OR we can simply work on making the whole setup better. 

This is properly fixed when examples are being tested in their own step instead of one big step that runs all the tests. 

Related issues/PRs: 

- https://github.com/prisma/prisma-examples/issues/1653
- https://github.com/prisma/prisma-examples/issues/1659
- https://github.com/prisma/prisma-examples/pull/2012