### PR TITLE
feat(deps): bump Prisma deps in latest

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,12 @@
       "baseBranchList": ["latest"],
       "packageNames": ["nexus-plugin-prisma"],
       "enabled": true
+    },
+    {
+      "baseBranchList": ["latest"],
+      "packageNames": ["@prisma/cli", "@prisma/client"],
+      "enabled": true,
+      "updateTypes": ["major"]
     }
-  ],
-  "ignoreDeps": ["@prisma/cli", "@prisma/client"]
+  ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
   },
   "masterIssue": true,
   "baseBranches": ["latest"],
+  "additionalReviewers": ["divyenduz", "nikolasburk"],
   "packageRules": [
     {
       "baseBranchList": ["latest"],

--- a/.github/scripts/check-for-update.sh
+++ b/.github/scripts/check-for-update.sh
@@ -65,16 +65,6 @@ while [ $i -le $count ]; do
 
     cd "$(dirname "$item")/"
 
-    hasNexusPluginPrisma="$(node -e "console.log(!!require('./package.json').dependencies['nexus-plugin-prisma'])")"
-
-    if [ "$hasNexusPluginPrisma" = "true" ]; then
-      echo "project uses nexus-plugin-prisma, ignoring"
-      yarn remove @prisma/cli || true
-      yarn remove @prisma/client || true
-      cd "$dir"
-      continue
-    fi
-
     vCLI="$(node -e "console.log(require('./package.json').devDependencies['@prisma/cli'])")"
 
     if [ "$vCLI" != "" ]; then

--- a/.github/workflows/keep-prisma-dependencies-updated.yaml
+++ b/.github/workflows/keep-prisma-dependencies-updated.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        branch: [latest, dev, patch-dev]
+        branch: [dev, patch-dev]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma-examples/issues/2063

This PR 

- Add renovate package rule to bump major versions of `@prisma/cli` and `@prisma/client` in `latest` branch
- Removed the stale code in our custom bump script that ignored Prisma dependencies in `nexus-prisma-plugin` projects
- Disables `latest` in our custom bump script

Note: at a later stage, we might want to write a renovate package rule that moves/bumps `@prisma/*` and `nexus-plugin-prisma` together. 