### PR TITLE
fix(grpc/rest-express/rest-fastify/rest-nextjs/rest-nuxtjs/script): added viewCount field to those schemas

### DIFF
--- a/javascript/grpc/prisma/schema.prisma
+++ b/javascript/grpc/prisma/schema.prisma
@@ -12,6 +12,7 @@ model Post {
   content   String?
   id        Int     @default(autoincrement()) @id
   published Boolean @default(false)
+  viewCount Int     @default(0)
   title     String
   author    User?   @relation(fields: [authorId], references: [id])
 }

--- a/javascript/rest-express/prisma/schema.prisma
+++ b/javascript/rest-express/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Post {
   content   String?
   id        Int     @default(autoincrement()) @id
   published Boolean @default(false)
+  viewCount Int     @default(0)
   title     String
   author    User?   @relation(fields: [authorId], references: [id])
 }

--- a/javascript/rest-fastify/prisma/schema.prisma
+++ b/javascript/rest-fastify/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Post {
   content   String?
   id        Int     @default(autoincrement()) @id
   published Boolean @default(false)
+  viewCount Int     @default(0)
   title     String
   author    User?   @relation(fields: [authorId], references: [id])
 }

--- a/javascript/rest-nextjs/prisma/schema.prisma
+++ b/javascript/rest-nextjs/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Post {
   content   String?
   id        Int     @default(autoincrement()) @id
   published Boolean @default(false)
+  viewCount Int     @default(0)
   title     String
   author    User?   @relation(fields: [authorId], references: [id])
 }

--- a/javascript/rest-nuxtjs/prisma/schema.prisma
+++ b/javascript/rest-nuxtjs/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Post {
   content   String?
   id        Int     @id @default(autoincrement())
   published Boolean @default(false)
+  viewCount Int     @default(0)
   title     String
   author    User?   @relation(fields: [authorId], references: [id])
 }

--- a/javascript/script/prisma/schema.prisma
+++ b/javascript/script/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Post {
   content   String?
   id        Int     @default(autoincrement()) @id
   published Boolean @default(false)
+  viewCount Int     @default(0)
   title     String
   author    User?   @relation(fields: [authorId], references: [id])
 }


### PR DESCRIPTION
The `seed.js` includes `viewCount`, but there aren’t `viewCount` field in the following schemas:

- grpc
- rest-express
- rest-fastify
- rest-nextjs
- rest-nuxtjs
- script