### PR TITLE
fix: npm build failing

### DIFF
--- a/typescript/graphql-auth/tsconfig.json
+++ b/typescript/graphql-auth/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
     "outDir": "dist",
     "rootDir": "src",
     "lib": ["esnext"],


### PR DESCRIPTION
fix `Error can only be default-imported using the 'esModuleInterop' flag` during `npm run build`

![image](https://user-images.githubusercontent.com/1742115/112731242-4e52fe80-8f36-11eb-8149-d5cb7792baa0.png)
