### PR TITLE
feat(deployment-platforms/aws-lambda): add exclusion for unneeded binaries

### DIFF
--- a/deployment-platforms/aws-lambda/serverless.yml
+++ b/deployment-platforms/aws-lambda/serverless.yml
@@ -38,3 +38,9 @@ functions:
       - http:
           method: GET
           path: /posts
+
+# only include the Prisma binary required on AWS Lambda while packaging
+package:
+  patterns:
+    - '!node_modules/.prisma/client/query-engine-*'
+    - 'node_modules/.prisma/client/query-engine-rhel-*'


### PR DESCRIPTION
To avoid problems like https://github.com/prisma/prisma/issues/6644, we want to filter out all binaries but the required on during the packaging step of Serverless Framework.

Related PR in docs that highlights this: https://github.com/prisma/docs/pull/1578
Related PR adding this to e2e tests as well: https://github.com/prisma/e2e-tests/pull/1637