### PR TITLE
fix: Sort contents of package.json 

### DIFF
--- a/databases/mongodb/package.json
+++ b/databases/mongodb/package.json
@@ -2,6 +2,9 @@
   "name": "prisma-mongo",
   "version": "1.0.0",
   "description": "",
+  "keywords": [],
+  "license": "ISC",
+  "author": "",
   "main": "index.js",
   "scripts": {
     "build": "tsc",
@@ -14,9 +17,9 @@
     "script:create-user-post": "ts-node src/prisma-examples/5-create-user-post.ts",
     "script:find-posts": "ts-node src/prisma-examples/6-find-posts.ts"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "dependencies": {
+    "@prisma/client": "2.24.1"
+  },
   "devDependencies": {
     "@types/jest": "26.0.23",
     "@types/node": "14.17.0",
@@ -25,8 +28,5 @@
     "ts-jest": "26.5.6",
     "ts-node": "10.0.0",
     "typescript": "4.3.2"
-  },
-  "dependencies": {
-    "@prisma/client": "2.24.1"
   }
 }

--- a/databases/sql-server/package.json
+++ b/databases/sql-server/package.json
@@ -1,23 +1,23 @@
 {
   "name": "sql-server-example",
   "version": "1.0.0",
+  "keywords": [],
+  "license": "ISC",
+  "author": "",
   "main": "index.js",
   "scripts": {
     "start": "node ./src/script.js",
     "test": "jest",
     "test:watch": "jest --watch"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "@prisma/client": "2.24.1",
     "jest": "^26.6.1"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
     "@types/jest": "26.0.23",
     "prettyjson": "1.2.1",
+    "prisma": "2.24.1",
     "ts-jest": "26.5.6",
     "ts-node": "10.0.0",
     "ts-node-dev": "1.1.6",

--- a/deployment-platforms/aws-lambda/package.json
+++ b/deployment-platforms/aws-lambda/package.json
@@ -1,16 +1,16 @@
 {
   "name": "prisma-aws-lambda-example",
-  "dependencies": {
-    "@prisma/client": "2.24.1"
-  },
+  "license": "MIT",
   "scripts": {
     "start": "node index.js",
     "prisma:introspect": "prisma introspect",
     "prisma:generate": "prisma generate"
   },
+  "dependencies": {
+    "@prisma/client": "2.24.1"
+  },
   "devDependencies": {
     "prisma": "2.24.1",
     "serverless-dotenv-plugin": "3.9.0"
-  },
-  "license": "MIT"
+  }
 }

--- a/deployment-platforms/azure-functions/package.json
+++ b/deployment-platforms/azure-functions/package.json
@@ -9,7 +9,7 @@
     "@prisma/client": "2.24.1"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
-    "azure-functions-core-tools": "3.0.3568"
+    "azure-functions-core-tools": "3.0.3568",
+    "prisma": "2.24.1"
   }
 }

--- a/javascript/graphql-auth/package.json
+++ b/javascript/graphql-auth/package.json
@@ -4,25 +4,25 @@
   "scripts": {
     "dev": "nodemon src/server.js"
   },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "all"
+  },
   "dependencies": {
     "@prisma/client": "2.24.1",
     "apollo-server": "2.25.1",
     "bcryptjs": "2.4.3",
     "graphql": "15.5.0",
-    "graphql-scalars": "1.10.0",
     "graphql-middleware": "6.0.10",
+    "graphql-scalars": "1.10.0",
     "graphql-shield": "7.5.0",
     "jsonwebtoken": "8.5.1",
     "nexus": "1.0.0"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
-    "nodemon": "2.0.7"
-  },
-  "prettier": {
-    "singleQuote": true,
-    "semi": false,
-    "trailingComma": "all"
+    "nodemon": "2.0.7",
+    "prisma": "2.24.1"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/javascript/graphql-sdl-first/package.json
+++ b/javascript/graphql-sdl-first/package.json
@@ -3,19 +3,19 @@
   "scripts": {
     "dev": "node ./src/server.js"
   },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "all"
+  },
   "dependencies": {
     "@prisma/client": "2.24.1",
+    "apollo-server": "2.25.1",
     "graphql": "15.5.0",
-    "graphql-scalars": "1.10.0",
-    "apollo-server": "2.25.1"
+    "graphql-scalars": "1.10.0"
   },
   "devDependencies": {
     "prisma": "2.24.1"
-  },
-  "prettier": {
-    "singleQuote": true,
-    "semi": false,
-    "trailingComma": "all"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/javascript/graphql/package.json
+++ b/javascript/graphql/package.json
@@ -2,6 +2,14 @@
   "name": "node-graphql",
   "version": "1.0.0",
   "license": "MIT",
+  "scripts": {
+    "dev": "nodemon src/server.js"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "all"
+  },
   "dependencies": {
     "@prisma/client": "2.24.1",
     "apollo-server": "2.25.1",
@@ -9,17 +17,9 @@
     "graphql-scalars": "1.10.0",
     "nexus": "1.0.0"
   },
-  "scripts": {
-    "dev": "nodemon src/server.js"
-  },
   "devDependencies": {
-    "prisma": "2.24.1",
-    "nodemon": "2.0.7"
-  },
-  "prettier": {
-    "singleQuote": true,
-    "semi": false,
-    "trailingComma": "all"
+    "nodemon": "2.0.7",
+    "prisma": "2.24.1"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/javascript/grpc/package.json
+++ b/javascript/grpc/package.json
@@ -1,11 +1,5 @@
 {
   "name": "node-grpc",
-  "dependencies": {
-    "@grpc/proto-loader": "0.6.2",
-    "@prisma/client": "2.24.1",
-    "chalk": "4.1.1",
-    "grpc": "1.24.10"
-  },
   "scripts": {
     "dev": "node ./server/server.js",
     "seed": "node prisma/seed.js",
@@ -16,6 +10,12 @@
     "createDraft": "node ./client/createDraft.js",
     "publish": "node ./client/publish.js",
     "deletePost": "node ./client/deletePost.js"
+  },
+  "dependencies": {
+    "@grpc/proto-loader": "0.6.2",
+    "@prisma/client": "2.24.1",
+    "chalk": "4.1.1",
+    "grpc": "1.24.10"
   },
   "devDependencies": {
     "prisma": "2.24.1"

--- a/javascript/rest-nextjs/package.json
+++ b/javascript/rest-nextjs/package.json
@@ -2,15 +2,15 @@
   "name": "hello-next",
   "version": "1.0.0",
   "description": "",
+  "keywords": [],
+  "license": "MIT",
+  "author": "",
   "main": "index.js",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
   "dependencies": {
     "@prisma/client": "2.24.1",
     "next": "^10.0.0",

--- a/javascript/rest-nuxtjs/package.json
+++ b/javascript/rest-nuxtjs/package.json
@@ -18,12 +18,12 @@
   "devDependencies": {
     "@nuxtjs/eslint-config": "6.0.1",
     "@nuxtjs/eslint-module": "3.0.2",
-    "prisma": "2.24.1",
     "babel-eslint": "10.1.0",
     "eslint": "7.28.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-nuxt": "2.0.0",
     "eslint-plugin-prettier": "3.4.0",
-    "prettier": "2.3.1"
+    "prettier": "2.3.1",
+    "prisma": "2.24.1"
   }
 }

--- a/javascript/script/package.json
+++ b/javascript/script/package.json
@@ -2,14 +2,14 @@
   "name": "script",
   "version": "1.0.0",
   "license": "MIT",
+  "scripts": {
+    "dev": "node ./script.js"
+  },
   "dependencies": {
     "@prisma/client": "2.24.1"
   },
   "devDependencies": {
     "prisma": "2.24.1"
-  },
-  "scripts": {
-    "dev": "node ./script.js"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/typescript/graphql-auth/package.json
+++ b/typescript/graphql-auth/package.json
@@ -10,13 +10,18 @@
     "generate:prisma": "prisma generate",
     "generate:nexus": "ts-node --transpile-only src/schema"
   },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "all"
+  },
   "dependencies": {
     "@prisma/client": "2.24.1",
     "apollo-server": "2.25.1",
     "bcryptjs": "2.4.3",
     "graphql": "15.5.0",
-    "graphql-scalars": "1.10.0",
     "graphql-middleware": "6.0.10",
+    "graphql-scalars": "1.10.0",
     "graphql-shield": "7.5.0",
     "jsonwebtoken": "8.5.1",
     "nexus": "1.0.0"
@@ -29,11 +34,6 @@
     "ts-node": "10.0.0",
     "ts-node-dev": "1.1.6",
     "typescript": "4.3.2"
-  },
-  "prettier": {
-    "singleQuote": true,
-    "semi": false,
-    "trailingComma": "all"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/typescript/graphql-express-sdl-first/package.json
+++ b/typescript/graphql-express-sdl-first/package.json
@@ -4,6 +4,11 @@
     "start": "node dist/server",
     "dev": "ts-node-dev --no-notify --respawn --transpile-only src/server"
   },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "all"
+  },
   "dependencies": {
     "@graphql-tools/schema": "7.1.5",
     "@prisma/client": "2.24.1",
@@ -19,11 +24,6 @@
     "ts-node": "10.0.0",
     "ts-node-dev": "1.1.6",
     "typescript": "4.3.2"
-  },
-  "prettier": {
-    "singleQuote": true,
-    "semi": false,
-    "trailingComma": "all"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/typescript/graphql-express/package.json
+++ b/typescript/graphql-express/package.json
@@ -10,6 +10,11 @@
     "generate:prisma": "prisma generate",
     "generate:nexus": "ts-node --transpile-only src/schema"
   },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "all"
+  },
   "dependencies": {
     "@prisma/client": "2.24.1",
     "express": "4.17.1",
@@ -19,17 +24,12 @@
     "nexus": "1.0.0"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
     "@types/express": "4.17.12",
     "@types/node": "12.20.15",
+    "prisma": "2.24.1",
     "ts-node": "10.0.0",
     "ts-node-dev": "1.1.6",
     "typescript": "4.3.2"
-  },
-  "prettier": {
-    "singleQuote": true,
-    "semi": false,
-    "trailingComma": "all"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/typescript/graphql-hapi-sdl-first/package.json
+++ b/typescript/graphql-hapi-sdl-first/package.json
@@ -8,10 +8,9 @@
   "dependencies": {
     "@hapi/hapi": "20.1.4",
     "@prisma/client": "2.24.1",
-    "graphql": "15.5.0",
-    "graphql-scalars": "1.10.0",
     "apollo-server-hapi": "2.25.1",
-    "graphql": "15.5.0"
+    "graphql": "15.5.0",
+    "graphql-scalars": "1.10.0"
   },
   "devDependencies": {
     "@types/hapi__hapi": "20.0.8",

--- a/typescript/graphql-hapi/package.json
+++ b/typescript/graphql-hapi/package.json
@@ -21,12 +21,12 @@
     "nexus": "1.0.0"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
     "@types/hapi__hapi": "20.0.8",
     "@types/node": "14.17.0",
+    "prisma": "2.24.1",
     "ts-node": "10.0.0",
-    "typescript": "4.3.2",
-    "ts-node-dev": "1.1.6"
+    "ts-node-dev": "1.1.6",
+    "typescript": "4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/typescript/graphql-nestjs-sdl-first/package.json
+++ b/typescript/graphql-nestjs-sdl-first/package.json
@@ -1,10 +1,10 @@
 {
   "name": "rest-nestjs",
   "version": "0.0.1",
-  "description": "",
-  "author": "",
   "private": true,
+  "description": "",
   "license": "UNLICENSED",
+  "author": "",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",
@@ -19,6 +19,23 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": "src",
+    "testEnvironment": "node",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    }
   },
   "dependencies": {
     "@nestjs/common": "7.6.17",
@@ -38,7 +55,6 @@
     "@nestjs/cli": "7.6.0",
     "@nestjs/schematics": "7.3.1",
     "@nestjs/testing": "7.6.17",
-    "prisma": "2.18.0",
     "@types/express": "4.17.12",
     "@types/jest": "26.0.23",
     "@types/node": "14.17.0",
@@ -57,22 +73,5 @@
     "ts-node": "10.0.0",
     "tsconfig-paths": "3.9.0",
     "typescript": "4.3.2"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/typescript/graphql-nestjs/package.json
+++ b/typescript/graphql-nestjs/package.json
@@ -1,10 +1,10 @@
 {
   "name": "rest-nestjs",
   "version": "0.0.1",
-  "description": "",
-  "author": "",
   "private": true,
+  "description": "",
   "license": "UNLICENSED",
+  "author": "",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",
@@ -19,6 +19,23 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": "src",
+    "testEnvironment": "node",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    }
   },
   "dependencies": {
     "@nestjs/common": "7.6.17",
@@ -38,7 +55,6 @@
     "@nestjs/cli": "7.6.0",
     "@nestjs/schematics": "7.3.1",
     "@nestjs/testing": "7.6.17",
-    "prisma": "2.24.1",
     "@types/express": "4.17.12",
     "@types/jest": "26.0.23",
     "@types/node": "14.17.0",
@@ -50,28 +66,12 @@
     "eslint-plugin-prettier": "3.4.0",
     "jest": "26.6.3",
     "prettier": "2.3.1",
+    "prisma": "2.24.1",
     "supertest": "6.1.3",
     "ts-jest": "26.5.6",
     "ts-loader": "9.2.3",
     "ts-node": "10.0.0",
     "tsconfig-paths": "3.9.0",
     "typescript": "4.3.2"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/typescript/graphql-nextjs/package.json
+++ b/typescript/graphql-nextjs/package.json
@@ -2,6 +2,9 @@
   "name": "hello-next",
   "version": "1.0.0",
   "description": "",
+  "keywords": [],
+  "license": "MIT",
+  "author": "",
   "scripts": {
     "dev": "next",
     "build": "next build",
@@ -10,9 +13,6 @@
     "generate:prisma": "prisma generate",
     "generate:nexus": "ts-node --transpile-only -P nexus.tsconfig.json pages/api"
   },
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
   "dependencies": {
     "@apollo/react-hooks": "4.0.0",
     "@apollo/react-ssr": "4.0.0",
@@ -33,10 +33,10 @@
     "react-markdown": "5.0.3"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
     "@types/graphql": "14.5.0",
     "@types/node": "13.13.52",
     "@types/react": "17.0.11",
+    "prisma": "2.24.1",
     "typescript": "4.3.2"
   }
 }

--- a/typescript/graphql-sdl-first/package.json
+++ b/typescript/graphql-sdl-first/package.json
@@ -3,11 +3,16 @@
   "scripts": {
     "dev": "ts-node-dev --no-notify --respawn --transpile-only src/server"
   },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "all"
+  },
   "dependencies": {
     "@prisma/client": "2.24.1",
+    "apollo-server": "2.25.1",
     "graphql": "15.5.0",
-    "graphql-scalars": "1.10.0",
-    "apollo-server": "2.25.1"
+    "graphql-scalars": "1.10.0"
   },
   "devDependencies": {
     "@types/graphql": "14.5.0",
@@ -17,11 +22,6 @@
     "ts-node": "10.0.0",
     "ts-node-dev": "1.1.6",
     "typescript": "4.3.2"
-  },
-  "prettier": {
-    "singleQuote": true,
-    "semi": false,
-    "trailingComma": "all"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/typescript/graphql-subscriptions/package.json
+++ b/typescript/graphql-subscriptions/package.json
@@ -10,6 +10,11 @@
     "generate:prisma": "prisma generate",
     "generate:nexus": "ts-node --transpile-only src/schema"
   },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "all"
+  },
   "dependencies": {
     "@prisma/client": "2.24.1",
     "apollo-server": "2.25.1",
@@ -17,16 +22,11 @@
     "nexus": "1.0.0"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
     "@types/node": "13.13.52",
+    "prisma": "2.24.1",
     "ts-node": "10.0.0",
     "ts-node-dev": "1.1.6",
     "typescript": "4.3.2"
-  },
-  "prettier": {
-    "semi": false,
-    "singleQuote": true,
-    "trailingComma": "all"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/typescript/graphql-typegraphql/package.json
+++ b/typescript/graphql-typegraphql/package.json
@@ -13,10 +13,10 @@
     "type-graphql": "1.1.1"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
     "@types/graphql": "14.5.0",
     "@types/node": "12.20.15",
     "@types/ws": "7.4.4",
+    "prisma": "2.24.1",
     "ts-node": "10.0.0",
     "ts-node-dev": "1.1.6",
     "typescript": "4.3.2"

--- a/typescript/graphql/package.json
+++ b/typescript/graphql/package.json
@@ -10,24 +10,24 @@
     "generate:prisma": "prisma generate",
     "generate:nexus": "ts-node --transpile-only src/schema"
   },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "all"
+  },
   "dependencies": {
-    "@prisma/client": "2.24.1",
-    "apollo-server": "2.25.1",
+    "@prisma/client": "^2.24.1",
+    "apollo-server": "2.25.0",
     "graphql": "15.5.0",
     "graphql-scalars": "1.10.0",
     "nexus": "1.0.0"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
-    "@types/node": "12.20.15",
+    "@types/node": "12.20.14",
+    "prisma": "^2.24.1",
     "ts-node": "10.0.0",
     "ts-node-dev": "1.1.6",
     "typescript": "4.3.2"
-  },
-  "prettier": {
-    "singleQuote": true,
-    "semi": false,
-    "trailingComma": "all"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/typescript/grpc/package.json
+++ b/typescript/grpc/package.json
@@ -1,12 +1,5 @@
 {
   "name": "typescript-grpc",
-  "dependencies": {
-    "@grpc/proto-loader": "0.6.2",
-    "@prisma/client": "2.24.1",
-    "chalk": "4.1.1",
-    "grpc": "1.24.10",
-    "protobufjs": "6.11.2"
-  },
   "scripts": {
     "dev": "ts-node ./server/server.ts",
     "seed": "ts-node prisma/seed.ts",
@@ -18,9 +11,16 @@
     "publish": "ts-node ./client/publish.ts",
     "deletePost": "ts-node ./client/deletePost.ts"
   },
+  "dependencies": {
+    "@grpc/proto-loader": "0.6.2",
+    "@prisma/client": "2.24.1",
+    "chalk": "4.1.1",
+    "grpc": "1.24.10",
+    "protobufjs": "6.11.2"
+  },
   "devDependencies": {
-    "prisma": "2.24.1",
     "@types/node": "13.13.52",
+    "prisma": "2.24.1",
     "ts-node": "10.0.0",
     "typescript": "4.3.2"
   },

--- a/typescript/postgis-express/package.json
+++ b/typescript/postgis-express/package.json
@@ -14,7 +14,6 @@
     "express": "4.17.1"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
     "@types/body-parser": "1.19.0",
     "@types/express": "4.17.12",
     "@types/jest": "26.0.23",
@@ -22,6 +21,7 @@
     "@types/supertest": "2.0.11",
     "jest": "26.6.3",
     "jest-environment-node": "26.6.2",
+    "prisma": "2.24.1",
     "randomstring": "1.2.1",
     "supertest": "6.1.3",
     "ts-jest": "26.5.6",

--- a/typescript/rest-express/package.json
+++ b/typescript/rest-express/package.json
@@ -10,9 +10,9 @@
     "express": "4.17.1"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
     "@types/express": "4.17.12",
     "@types/node": "12.20.15",
+    "prisma": "2.24.1",
     "ts-node": "10.0.0",
     "typescript": "4.3.2"
   },

--- a/typescript/rest-hapi/package.json
+++ b/typescript/rest-hapi/package.json
@@ -11,10 +11,10 @@
     "@types/node": "12.20.15"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
     "@types/express": "4.17.12",
     "@types/hapi__hapi": "20.0.8",
     "@types/node": "12.20.15",
+    "prisma": "2.24.1",
     "ts-node": "10.0.0",
     "typescript": "4.3.2"
   },

--- a/typescript/rest-nestjs/package.json
+++ b/typescript/rest-nestjs/package.json
@@ -1,10 +1,10 @@
 {
   "name": "rest-nestjs",
   "version": "0.0.1",
-  "description": "",
-  "author": "",
   "private": true,
+  "description": "",
   "license": "UNLICENSED",
+  "author": "",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",
@@ -20,6 +20,23 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
+  "jest": {
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": "src",
+    "testEnvironment": "node",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    }
+  },
   "dependencies": {
     "@nestjs/common": "7.6.17",
     "@nestjs/core": "7.6.17",
@@ -33,7 +50,6 @@
     "@nestjs/cli": "7.6.0",
     "@nestjs/schematics": "7.3.1",
     "@nestjs/testing": "7.6.17",
-    "prisma": "2.24.1",
     "@types/express": "4.17.12",
     "@types/jest": "26.0.23",
     "@types/node": "14.17.0",
@@ -45,28 +61,12 @@
     "eslint-plugin-prettier": "3.4.0",
     "jest": "26.6.3",
     "prettier": "2.3.1",
+    "prisma": "2.24.1",
     "supertest": "6.1.3",
     "ts-jest": "26.5.6",
     "ts-loader": "9.2.3",
     "ts-node": "10.0.0",
     "tsconfig-paths": "3.9.0",
     "typescript": "4.3.2"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/typescript/rest-nextjs-api-routes-auth/package.json
+++ b/typescript/rest-nextjs-api-routes-auth/package.json
@@ -2,15 +2,15 @@
   "name": "hello-next",
   "version": "1.0.0",
   "description": "",
+  "keywords": [],
+  "license": "MIT",
+  "author": "",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start",
     "ts-node": "ts-node --compiler-options {\\\"module\\\":\\\"commonjs\\\"}"
   },
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
   "dependencies": {
     "@prisma/client": "2.24.1",
     "next": "10.2.3",

--- a/typescript/rest-nextjs-api-routes/package.json
+++ b/typescript/rest-nextjs-api-routes/package.json
@@ -2,15 +2,15 @@
   "name": "hello-next",
   "version": "1.0.0",
   "description": "",
+  "keywords": [],
+  "license": "MIT",
+  "author": "",
   "main": "index.js",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
   "dependencies": {
     "@prisma/client": "2.24.1",
     "next": "^10.0.0",
@@ -19,9 +19,9 @@
     "react-markdown": "^5.0.0"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
     "@types/node": "13.13.52",
     "@types/react": "17.0.11",
+    "prisma": "2.24.1",
     "typescript": "4.3.2"
   }
 }

--- a/typescript/rest-nextjs-express/backend/package.json
+++ b/typescript/rest-nextjs-express/backend/package.json
@@ -11,9 +11,9 @@
     "express": "4.17.1"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
     "@types/express": "4.17.12",
     "@types/node": "12.20.15",
+    "prisma": "2.24.1",
     "ts-node": "10.0.0",
     "typescript": "4.3.2"
   },

--- a/typescript/rest-nextjs-express/frontend/package.json
+++ b/typescript/rest-nextjs-express/frontend/package.json
@@ -2,15 +2,15 @@
   "name": "hello-next",
   "version": "1.0.0",
   "description": "",
+  "keywords": [],
+  "license": "MIT",
+  "author": "",
   "main": "index.js",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
   "dependencies": {
     "next": "^10.0.0",
     "react": "^17.0.0",

--- a/typescript/script/package.json
+++ b/typescript/script/package.json
@@ -1,17 +1,17 @@
 {
   "name": "script",
   "license": "MIT",
-  "devDependencies": {
-    "prisma": "2.24.1",
-    "ts-node": "10.0.0",
-    "typescript": "4.3.2"
-  },
   "scripts": {
     "dev": "ts-node ./script.ts"
   },
   "dependencies": {
     "@prisma/client": "2.24.1",
     "@types/node": "13.13.52"
+  },
+  "devDependencies": {
+    "prisma": "2.24.1",
+    "ts-node": "10.0.0",
+    "typescript": "4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/typescript/testing-express/package.json
+++ b/typescript/testing-express/package.json
@@ -6,13 +6,16 @@
     "dev": "ts-node src/index.ts",
     "test": "jest"
   },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
+  },
   "dependencies": {
     "@prisma/client": "2.24.1",
     "@types/node": "12.20.15",
     "express": "4.17.1"
   },
   "devDependencies": {
-    "prisma": "2.24.1",
     "@types/express": "4.17.12",
     "@types/jest": "26.0.23",
     "@types/node": "12.20.15",
@@ -20,6 +23,7 @@
     "jest": "26.6.3",
     "jest-environment-node": "26.6.2",
     "nanoid": "3.1.23",
+    "prisma": "2.24.1",
     "supertest": "6.1.3",
     "ts-jest": "26.5.6",
     "ts-node": "10.0.0",
@@ -27,9 +31,5 @@
   },
   "engines": {
     "node": ">=10.0.0"
-  },
-  "prettier": {
-    "semi": false,
-    "singleQuote": true
   }
 }


### PR DESCRIPTION
Fix #2907 

Used `npx sort-package-json` to sort the order of dependencies and contents of `package.json` of all examples
