### PR TITLE
fix(javascript/rest-nuxtjs): wrong `signup` endpoint onSubmit

### DIFF
--- a/javascript/rest-nuxtjs/pages/signup.vue
+++ b/javascript/rest-nuxtjs/pages/signup.vue
@@ -27,7 +27,7 @@ export default {
           email: this.email,
         }
 
-        const res = await fetch(`http://localhost:3000/api/signup`, {
+        const res = await fetch(`http://localhost:3000/api/user`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),


### PR DESCRIPTION
Hey there 👋 I recently tried to test the Nuxt - Prisma example and I noticed that the `signup` onSubmit action targeted the wrong endpoint (singup instead of user).

I decided to change the actual fetch instead of the endpoint but if you think it's the other way around please let me know. 

Hope this helps! 