### PR TITLE
chore: Update README.md

### DIFF
--- a/typescript/graphql-nextjs/README.md
+++ b/typescript/graphql-nextjs/README.md
@@ -350,7 +350,7 @@ const Mutation = objectType({
 +       bio: stringArg()
 +     }, 
 +     resolve: async (_, args, context) => {
-+       return context.prisma.profile.create({
++       return prisma.profile.create({
 +         data: {
 +           bio: args.bio,
 +           user: {


### PR DESCRIPTION
This small bug (prisma is a global now and now using "context" which IMHO it really should, even if in context it refers to the global.)

At any rate, this fix is just for the graphql-nextjs example. I believe this error is propagated through all the other examples also.

(Also, a little unrelated and too big to fix for me, getInitialProps is outdated in this example)