### PR TITLE
chore: update apollo server example

### DIFF
--- a/javascript/graphql-auth/package.json
+++ b/javascript/graphql-auth/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@prisma/client": "2.30.2",
-    "apollo-server": "2.25.2",
+    "apollo-server": "3.3.0",
     "bcryptjs": "2.4.3",
     "graphql": "15.5.2",
     "graphql-middleware": "6.1.4",

--- a/javascript/graphql-sdl-first/package.json
+++ b/javascript/graphql-sdl-first/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@prisma/client": "2.30.2",
-    "apollo-server": "2.25.2",
+    "apollo-server": "3.3.0",
     "graphql": "15.5.2",
     "graphql-scalars": "1.10.0"
   },

--- a/javascript/graphql-sdl-first/src/server.js
+++ b/javascript/graphql-sdl-first/src/server.js
@@ -1,14 +1,11 @@
 const { ApolloServer } = require('apollo-server')
-const { schema } = require('./schema')
+const { typeDefs, resolvers } = require('./schema')
 const { context } = require('./context')
 
-const server = new ApolloServer({ schema, context: context })
+const server = new ApolloServer({ typeDefs, resolvers, context: context })
 
-server
-  .listen()
-  .then(({ url }) =>
-    console.log(`
+server.listen().then(({ url }) =>
+  console.log(`
 🚀 Server ready at: ${url}
-⭐️ See sample queries: http://pris.ly/e/js/graphql-sdl-first#using-the-graphql-api`,
-    ),
-  )
+⭐️ See sample queries: http://pris.ly/e/js/graphql-sdl-first#using-the-graphql-api`),
+)

--- a/javascript/graphql/package.json
+++ b/javascript/graphql/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@prisma/client": "2.30.2",
-    "apollo-server": "2.25.2",
+    "apollo-server": "3.3.0",
     "graphql": "15.5.2",
     "graphql-scalars": "1.10.0",
     "nexus": "1.1.0"

--- a/typescript/graphql-auth/package.json
+++ b/typescript/graphql-auth/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@prisma/client": "2.30.2",
-    "apollo-server": "2.25.2",
+    "apollo-server": "3.3.0",
     "bcryptjs": "2.4.3",
     "graphql": "15.5.2",
     "graphql-middleware": "6.1.4",

--- a/typescript/graphql-sdl-first/package.json
+++ b/typescript/graphql-sdl-first/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@prisma/client": "2.30.2",
-    "apollo-server": "2.25.2",
+    "apollo-server": "3.3.0",
     "graphql": "15.5.2",
     "graphql-scalars": "1.10.0"
   },

--- a/typescript/graphql-sdl-first/src/schema.ts
+++ b/typescript/graphql-sdl-first/src/schema.ts
@@ -1,8 +1,8 @@
-import { makeExecutableSchema } from 'apollo-server'
+import { gql } from 'apollo-server'
 import { DateTimeResolver } from 'graphql-scalars'
 import { Context } from './context'
 
-const typeDefs = `
+export const typeDefs = gql`
 type Mutation {
   createDraft(authorEmail: String!, data: PostCreateInput!): Post
   deletePost(id: Int!): Post
@@ -64,7 +64,7 @@ input UserUniqueInput {
 scalar DateTime
 `
 
-const resolvers = {
+export const resolvers = {
   Query: {
     allUsers: (_parent, _args, context: Context) => {
       return context.prisma.user.findMany()
@@ -213,9 +213,4 @@ interface UserCreateInput {
   name?: string,
   posts?: PostCreateInput[],
 }
-
-export const schema = makeExecutableSchema({
-  resolvers,
-  typeDefs,
-})
 

--- a/typescript/graphql-sdl-first/src/server.ts
+++ b/typescript/graphql-sdl-first/src/server.ts
@@ -1,12 +1,11 @@
 import { ApolloServer } from 'apollo-server'
-import { schema } from './schema'
+import { resolvers, typeDefs } from './schema'
 import { context } from './context'
 
-new ApolloServer({ schema, context: context }).listen(
+new ApolloServer({ resolvers, typeDefs, context: context }).listen(
   { port: 4000 },
   () =>
     console.log(`
 🚀 Server ready at: http://localhost:4000
-⭐️ See sample queries: http://pris.ly/e/ts/graphql-sdl-first#using-the-graphql-api`,
-    ),
+⭐️ See sample queries: http://pris.ly/e/ts/graphql-sdl-first#using-the-graphql-api`),
 )

--- a/typescript/graphql-typegraphql-crud/package.json
+++ b/typescript/graphql-typegraphql-crud/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@prisma/client": "2.30.2",
     "@types/graphql-fields": "1.3.4",
-    "apollo-server": "2.25.2",
+    "apollo-server": "3.3.0",
     "class-validator": "0.13.1",
     "graphql": "15.5.2",
     "graphql-fields": "2.0.3",

--- a/typescript/graphql-typegraphql/package.json
+++ b/typescript/graphql-typegraphql/package.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "@prisma/client": "2.30.2",
-    "apollo-server": "2.25.2",
+    "apollo-server": "3.3.0",
     "class-validator": "0.13.1",
     "graphql": "15.5.2",
     "graphql-scalars": "1.10.0",

--- a/typescript/graphql/package.json
+++ b/typescript/graphql/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@prisma/client": "2.30.2",
-    "apollo-server": "2.25.2",
+    "apollo-server": "3.3.0",
     "graphql": "15.5.2",
     "graphql-scalars": "1.10.0",
     "nexus": "1.1.0"


### PR DESCRIPTION
This PR updates both JS and TS GraphQL examples that were using Apollo Server 2.

Affected examples:
- JavaScript
  -  `graphql`
  - `graphql-auth`
  - `graphql-sdl-first`
- TypeScript
  - `graphql`
  - `graphql-auth`
  - `graphql-sdl-first`
  - `graphql-typegraphql` 
  - `graphql-typegraphql-crud` 