### PR TITLE
Fix issue #3153

### DIFF
--- a/typescript/graphql-nextjs/package.json
+++ b/typescript/graphql-nextjs/package.json
@@ -40,6 +40,6 @@
     "typescript": "4.4.3"
   },
   "prisma": {
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "npm run ts-node prisma/seed.ts"
   }
 }


### PR DESCRIPTION
`ts-node` needs to run with `{"module": "commonjs"}` compiler option, otherwise the `npx prisma db seed` command fails.