### PR TITLE
docs(readmes): fix ts/graphql-nextjs typo

### DIFF
--- a/.github/readmes/typescript/_evolving-the-app-graphql-nextjs.md
+++ b/.github/readmes/typescript/_evolving-the-app-graphql-nextjs.md
@@ -57,7 +57,7 @@ You can now use your `PrismaClient` instance to perform operations against the n
 First, add a new GraphQL type via Nexus' `objectType` function:
 
 ```diff
-// ./src/schema.ts
+// ./pages/api/index.ts
 
 +const Profile = objectType({
 +  name: 'Profile',
@@ -92,6 +92,7 @@ const User = objectType({
           })
           .posts()
       },
+    })
 +   t.field('profile', {
 +     type: 'Profile',
 +     resolve: (parent, _, context) => {

--- a/typescript/graphql-nextjs/README.md
+++ b/typescript/graphql-nextjs/README.md
@@ -261,7 +261,7 @@ You can now use your `PrismaClient` instance to perform operations against the n
 First, add a new GraphQL type via Nexus' `objectType` function:
 
 ```diff
-// ./src/schema.ts
+// ./pages/api/index.ts
 
 +const Profile = objectType({
 +  name: 'Profile',
@@ -296,6 +296,7 @@ const User = objectType({
           })
           .posts()
       },
+    })
 +   t.field('profile', {
 +     type: 'Profile',
 +     resolve: (parent, _, context) => {


### PR DESCRIPTION
Fix a typos and a formatting error in `README.md`.