### PR TITLE
chore(typescript/graphql-nextjs): update example README

### DIFF
--- a/.github/readmes/typescript/_evolving-the-app-graphql-nextjs.md
+++ b/.github/readmes/typescript/_evolving-the-app-graphql-nextjs.md
@@ -66,8 +66,8 @@ First, add a new GraphQL type via Nexus' `objectType` function:
 +    t.string('bio')
 +    t.field('user', {
 +      type: 'User',
-+      resolve: (parent, _, context) => {
-+        return context.prisma.profile
++      resolve: (parent, _,) => {
++        return prisma.profile
 +          .findUnique({
 +            where: { id: parent.id || undefined },
 +          })
@@ -86,7 +86,7 @@ const User = objectType({
     t.nonNull.list.nonNull.field('posts', {
       type: 'Post',
       resolve: (parent, _, context) => {
-        return context.prisma.user
+        return prisma.user
           .findUnique({
             where: { id: parent.id || undefined },
           })
@@ -95,7 +95,7 @@ const User = objectType({
 +   t.field('profile', {
 +     type: 'Profile',
 +     resolve: (parent, _, context) => {
-+       return context.prisma.user.findUnique({
++       return prisma.user.findUnique({
 +         where: { id: parent.id }
 +       }).profile()
 +     }
@@ -140,7 +140,7 @@ const Mutation = objectType({
 +       bio: stringArg()
 +     }, 
 +     resolve: async (_, args, context) => {
-+       return context.prisma.profile.create({
++       return prisma.profile.create({
 +         data: {
 +           bio: args.bio,
 +           user: {

--- a/.github/readmes/typescript/_evolving-the-app-graphql-nextjs.md
+++ b/.github/readmes/typescript/_evolving-the-app-graphql-nextjs.md
@@ -66,7 +66,7 @@ First, add a new GraphQL type via Nexus' `objectType` function:
 +    t.string('bio')
 +    t.field('user', {
 +      type: 'User',
-+      resolve: (parent, _,) => {
++      resolve: (parent) => {
 +        return prisma.profile
 +          .findUnique({
 +            where: { id: parent.id || undefined },
@@ -85,7 +85,7 @@ const User = objectType({
     t.nonNull.string('email')
     t.nonNull.list.nonNull.field('posts', {
       type: 'Post',
-      resolve: (parent, _, context) => {
+      resolve: (parent) => {
         return prisma.user
           .findUnique({
             where: { id: parent.id || undefined },
@@ -94,7 +94,7 @@ const User = objectType({
       },
 +   t.field('profile', {
 +     type: 'Profile',
-+     resolve: (parent, _, context) => {
++     resolve: (parent) => {
 +       return prisma.user.findUnique({
 +         where: { id: parent.id }
 +       }).profile()
@@ -139,7 +139,7 @@ const Mutation = objectType({
 +       email: stringArg(),
 +       bio: stringArg()
 +     }, 
-+     resolve: async (_, args, context) => {
++     resolve: async (_, args) => {
 +       return prisma.profile.create({
 +         data: {
 +           bio: args.bio,

--- a/typescript/graphql-nextjs/README.md
+++ b/typescript/graphql-nextjs/README.md
@@ -350,7 +350,7 @@ const Mutation = objectType({
 +       bio: stringArg()
 +     }, 
 +     resolve: async (_, args, context) => {
-+       return context.prisma.profile.create({
++       return prisma.profile.create({
 +         data: {
 +           bio: args.bio,
 +           user: {

--- a/typescript/graphql-nextjs/README.md
+++ b/typescript/graphql-nextjs/README.md
@@ -276,8 +276,8 @@ First, add a new GraphQL type via Nexus' `objectType` function:
 +    t.string('bio')
 +    t.field('user', {
 +      type: 'User',
-+      resolve: (parent, _, context) => {
-+        return context.prisma.profile
++      resolve: (parent, _,) => {
++        return prisma.profile
 +          .findUnique({
 +            where: { id: parent.id || undefined },
 +          })
@@ -296,7 +296,7 @@ const User = objectType({
     t.nonNull.list.nonNull.field('posts', {
       type: 'Post',
       resolve: (parent, _, context) => {
-        return context.prisma.user
+        return prisma.user
           .findUnique({
             where: { id: parent.id || undefined },
           })
@@ -305,7 +305,7 @@ const User = objectType({
 +   t.field('profile', {
 +     type: 'Profile',
 +     resolve: (parent, _, context) => {
-+       return context.prisma.user.findUnique({
++       return prisma.user.findUnique({
 +         where: { id: parent.id }
 +       }).profile()
 +     }

--- a/typescript/graphql-nextjs/README.md
+++ b/typescript/graphql-nextjs/README.md
@@ -276,7 +276,7 @@ First, add a new GraphQL type via Nexus' `objectType` function:
 +    t.string('bio')
 +    t.field('user', {
 +      type: 'User',
-+      resolve: (parent, _,) => {
++      resolve: (parent) => {
 +        return prisma.profile
 +          .findUnique({
 +            where: { id: parent.id || undefined },
@@ -295,7 +295,7 @@ const User = objectType({
     t.nonNull.string('email')
     t.nonNull.list.nonNull.field('posts', {
       type: 'Post',
-      resolve: (parent, _, context) => {
+      resolve: (parent) => {
         return prisma.user
           .findUnique({
             where: { id: parent.id || undefined },
@@ -304,7 +304,7 @@ const User = objectType({
       },
 +   t.field('profile', {
 +     type: 'Profile',
-+     resolve: (parent, _, context) => {
++     resolve: (parent) => {
 +       return prisma.user.findUnique({
 +         where: { id: parent.id }
 +       }).profile()
@@ -349,7 +349,7 @@ const Mutation = objectType({
 +       email: stringArg(),
 +       bio: stringArg()
 +     }, 
-+     resolve: async (_, args, context) => {
++     resolve: async (_, args) => {
 +       return prisma.profile.create({
 +         data: {
 +           bio: args.bio,


### PR DESCRIPTION
Remove any mention of `context.` from the queries and mutations as the example doesn't use it anywhere.