### PR TITLE
chore: update aws-lambda example

### DIFF
--- a/deployment-platforms/aws-lambda/README.md
+++ b/deployment-platforms/aws-lambda/README.md
@@ -8,3 +8,5 @@
 curl https://codeload.github.com/prisma/prisma-examples/tar.gz/latest | tar -xz --strip=2 prisma-examples-latest/deployment-platforms/aws-lambda
 cd aws-lambda
 ```
+
+The Serverless configuration file includes a package pattern that excludes all Prisma Engine binaries but the one relevant for the Lambda runtime. You can read more in our [documentation](https://www.prisma.io/docs/guides/deployment/deployment-guides/deploying-to-aws-lambda#package-pattern-in-serverlessyml).

--- a/deployment-platforms/aws-lambda/serverless.yml
+++ b/deployment-platforms/aws-lambda/serverless.yml
@@ -44,3 +44,5 @@ package:
   patterns:
     - '!node_modules/.prisma/client/libquery_engine-*'
     - 'node_modules/.prisma/client/libquery_engine-rhel-*'
+    - '!node_modules/prisma/libquery_engine-*'
+    - '!node_modules/@prisma/engines/**'

--- a/deployment-platforms/aws-lambda/serverless.yml
+++ b/deployment-platforms/aws-lambda/serverless.yml
@@ -42,5 +42,5 @@ functions:
 # only include the Prisma binary required on AWS Lambda while packaging
 package:
   patterns:
-    - '!node_modules/.prisma/client/query-engine-*'
-    - 'node_modules/.prisma/client/query-engine-rhel-*'
+    - '!node_modules/.prisma/client/libquery_engine-*'
+    - 'node_modules/.prisma/client/libquery_engine-rhel-*'


### PR DESCRIPTION
Update package pattern to `libquery...`

The initial version was leading to a deployment error about the size of the zipped size