### PR TITLE
fix: React Markdown syntax update (partial)

### DIFF
--- a/typescript/rest-nextjs-api-routes-auth/components/Post.tsx
+++ b/typescript/rest-nextjs-api-routes-auth/components/Post.tsx
@@ -19,7 +19,7 @@ const Post: React.FC<{ post: PostProps }> = ({ post }) => {
     <div onClick={() => Router.push("/p/[id]", `/p/${post.id}`)}>
       <h2>{post.title}</h2>
       <small>By {authorName}</small>
-      <ReactMarkdown source={post.content} />
+      <ReactMarkdown children={post.content} />
       <style jsx>{`
         div {
           color: inherit;

--- a/typescript/rest-nextjs-api-routes-auth/pages/p/[id].tsx
+++ b/typescript/rest-nextjs-api-routes-auth/pages/p/[id].tsx
@@ -55,7 +55,7 @@ const Post: React.FC<PostProps> = (props) => {
       <div>
         <h2>{title}</h2>
         <p>By {props?.author?.name || "Unknown author"}</p>
-        <ReactMarkdown source={props.content} />
+        <ReactMarkdown children={props.content} />
         {!props.published && userHasValidSession && postBelongsToUser && (
           <button onClick={() => publishPost(props.id)}>Publish</button>
         )}


### PR DESCRIPTION
Post.tsx component and [id].tsx page in most (if not all) repos require this fix.

"source" is obsolete and should be replaced with "children". 

I am a newbie so changed just a single repo to be safe.