### PR TITLE
don't fetch from the api using a hardcoded host

### DIFF
--- a/.github/tests/javascript/rest-nextjs/run.sh
+++ b/.github/tests/javascript/rest-nextjs/run.sh
@@ -9,8 +9,6 @@ pid=$!
 
 sleep 15
 
-curl --fail 'http://localhost:3000/api/feed?searchString=Prisma'
-
 # check frontend
 curl --fail 'http://localhost:3000/'
 

--- a/javascript/rest-nextjs/lib/util.js
+++ b/javascript/rest-nextjs/lib/util.js
@@ -1,0 +1,8 @@
+
+// Make an object serializable to JSON.
+//
+// Useful to convert an object which may contain non-serializeable data such as
+// Dates to an object that doesn't
+export function makeSerializable (o) {
+    return JSON.parse(JSON.stringify(o))
+}

--- a/javascript/rest-nextjs/pages/api/drafts.js
+++ b/javascript/rest-nextjs/pages/api/drafts.js
@@ -1,9 +1,0 @@
-import prisma from '../../lib/prisma'
-
-export default async function handle(req, res) {
-  const posts = await prisma.post.findMany({
-    where: { published: false },
-    include: { author: true },
-  })
-  res.json(posts)
-}

--- a/javascript/rest-nextjs/pages/api/feed.js
+++ b/javascript/rest-nextjs/pages/api/feed.js
@@ -1,9 +1,0 @@
-import prisma from '../../lib/prisma'
-
-export default async function handle(req, res) {
-  const posts = await prisma.post.findMany({
-    where: { published: true },
-    include: { author: true },
-  })
-  res.json(posts)
-}

--- a/javascript/rest-nextjs/pages/api/post/[id].js
+++ b/javascript/rest-nextjs/pages/api/post/[id].js
@@ -3,24 +3,13 @@ import prisma from '../../../lib/prisma'
 export default async function handle(req, res) {
   const postId = req.query.id
 
-  if (req.method === 'GET') {
-    handleGET(postId, res)
-  } else if (req.method === 'DELETE') {
+  if (req.method === 'DELETE') {
     handleDELETE(postId, res)
   } else {
     throw new Error(
       `The HTTP ${req.method} method is not supported at this route.`
     )
   }
-}
-
-// GET /api/post/:id
-async function handleGET(postId, res) {
-  const post = await prisma.post.findUnique({
-    where: { id: Number(postId) },
-    include: { author: true },
-  })
-  res.json(post)
 }
 
 // DELETE /api/post/:id

--- a/javascript/rest-nextjs/pages/drafts.jsx
+++ b/javascript/rest-nextjs/pages/drafts.jsx
@@ -1,5 +1,7 @@
 import Layout from '../components/Layout'
 import Post from '../components/Post'
+import prisma from '../lib/prisma'
+import { makeSerializable } from '../lib/util';
 
 const Drafts = props => {
   return (
@@ -33,10 +35,12 @@ const Drafts = props => {
 }
 
 export const getServerSideProps = async () => {
-  const res = await fetch('http://localhost:3000/api/drafts')
-  const drafts = await res.json()
+  const drafts = await prisma.post.findMany({
+    where: { published: false },
+    include: { author: true },
+  })
   return {
-    props: { drafts },
+    props: { drafts: makeSerializable(drafts) },
   }
 }
 

--- a/javascript/rest-nextjs/pages/index.jsx
+++ b/javascript/rest-nextjs/pages/index.jsx
@@ -1,5 +1,7 @@
 import Layout from '../components/Layout'
 import Post from '../components/Post'
+import { makeSerializable } from '../lib/util'
+import prisma from '../lib/prisma';
 
 const Blog = props => {
   return (
@@ -33,10 +35,12 @@ const Blog = props => {
 }
 
 export const getServerSideProps = async () => {
-  const res = await fetch('http://localhost:3000/api/feed')
-  const feed = await res.json()
+  const feed = await prisma.post.findMany({
+    where: { published: true },
+    include: { author: true },
+  })
   return {
-    props: { feed },
+    props: { feed: makeSerializable(feed) },
   }
 }
 

--- a/javascript/rest-nextjs/pages/p/[id].jsx
+++ b/javascript/rest-nextjs/pages/p/[id].jsx
@@ -1,6 +1,8 @@
 import ReactMarkdown from 'react-markdown'
 import Layout from '../../components/Layout'
 import Router from 'next/router'
+import { makeSerializable } from '../../lib/util'
+import prisma from '../../lib/prisma';
 
 async function publish(id) {
   await fetch(`/api/publish/${id}`, {
@@ -61,9 +63,11 @@ const Post = props => {
 }
 
 export const getServerSideProps = async (context) => {
-  const res = await fetch(`http://localhost:3000/api/post/${context.params.id}`)
-  const data = await res.json()
-  return { props: { ...data } }
+  const post = await prisma.post.findUnique({
+    where: { id: Number(context.params.id) },
+    include: { author: true },
+  })
+  return { props: { ...makeSerializable(post) } }
 }
 
 export default Post


### PR DESCRIPTION
In some cases, localhost:3000 won't be where the api is deployed to. For frontend code, just pass the path to fetch so it uses the same host.
Restructured server-side code to use library calls and avoid fetch which is considered a best practice for Next.js.