### PR TITLE
chore: remove unsupported endpoint

### DIFF
--- a/.github/readmes/_using-the-rest-api-nextjs.md
+++ b/.github/readmes/_using-the-rest-api-nextjs.md
@@ -4,7 +4,6 @@ You can also access the REST API of the API server directly. It is running on th
 
 ### `GET`
 
-- `/api/post/:id`: Fetch a single post by its `id`
 - `/api/feed`: Fetch all _published_ posts
 - `/api/filterPosts?searchString={searchString}`: Filter posts by `title` or `content`
 
@@ -25,5 +24,5 @@ You can also access the REST API of the API server directly. It is running on th
 - `/api/publish/:id`: Publish a post by its `id`
 
 ### `DELETE`
-  
+
 - `/api/post/:id`: Delete a post by its `id`

--- a/javascript/rest-nextjs/README.md
+++ b/javascript/rest-nextjs/README.md
@@ -86,7 +86,6 @@ You can also access the REST API of the API server directly. It is running on th
 
 ### `GET`
 
-- `/api/post/:id`: Fetch a single post by its `id`
 - `/api/feed`: Fetch all _published_ posts
 - `/api/filterPosts?searchString={searchString}`: Filter posts by `title` or `content`
 
@@ -107,7 +106,7 @@ You can also access the REST API of the API server directly. It is running on th
 - `/api/publish/:id`: Publish a post by its `id`
 
 ### `DELETE`
-  
+
 - `/api/post/:id`: Delete a post by its `id`
 
 ## Switch to another database (e.g. PostgreSQL, MySQL, SQL Server, MongoDB)

--- a/typescript/rest-nextjs-api-routes/README.md
+++ b/typescript/rest-nextjs-api-routes/README.md
@@ -107,7 +107,7 @@ You can also access the REST API of the API server directly. It is running on th
 - `/api/publish/:id`: Publish a post by its `id`
 
 ### `DELETE`
-  
+
 - `/api/post/:id`: Delete a post by its `id`
 
 ## Evolving the app

--- a/typescript/rest-nextjs-api-routes/README.md
+++ b/typescript/rest-nextjs-api-routes/README.md
@@ -87,7 +87,6 @@ You can also access the REST API of the API server directly. It is running on th
 
 ### `GET`
 
-- `/api/post/:id`: Fetch a single post by its `id`
 - `/api/feed`: Fetch all _published_ posts
 - `/api/filterPosts?searchString={searchString}`: Filter posts by `title` or `content`
 


### PR DESCRIPTION
`GET /api/post/:id` is not implemented, so I removed it from the README

## How to reproduce

Follow the instructions to run the example and then run: `curl 127.0.0.1:3000/api/post/1`.

## Alternative solution for this issue

If you want to implement this GET endpoint, I can open an issue.