### PR TITLE
adding declare to remove TS warning for "global.prisma"

### DIFF
--- a/typescript/rest-nextjs-api-routes-auth/lib/prisma.ts
+++ b/typescript/rest-nextjs-api-routes-auth/lib/prisma.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from "@prisma/client";
+declare var global: { prisma: PrismaClient };
 
 // PrismaClient is attached to the `global` object in development to prevent
 // exhausting your database connection limit.


### PR DESCRIPTION
"global.prisma" is giving warning (Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.) because  is not define in global variable  and typescript is type safe, 

So that I am adding declare key word to define type safety "global.prisma" as per typescript standards