### PR TITLE
Update prisma.ts

### DIFF
--- a/typescript/rest-nextjs-api-routes-auth/lib/prisma.ts
+++ b/typescript/rest-nextjs-api-routes-auth/lib/prisma.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from "@prisma/client";
-declare var global: { prisma: PrismaClient };
+declare let global: { prisma: PrismaClient };
 
 // PrismaClient is attached to the `global` object in development to prevent
 // exhausting your database connection limit.


### PR DESCRIPTION
declare clause with `var` causes redundant eslint-disabling code; `eslint-disable-next-line no-var`. I think there is no reason to use `var` in this case.