### PR TITLE
Set --transpile-only for Typescript

### DIFF
--- a/typescript/graphql/package.json
+++ b/typescript/graphql/package.json
@@ -30,6 +30,6 @@
     "typescript": "4.8.4"
   },
   "prisma": {
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "ts-node --transpile-only prisma/seed.ts"
   }
 }


### PR DESCRIPTION
When calling 'seed', if we don't have transpile-only flag set, we will end up with an empty database.

Set the flag so the example works as intended.