### PR TITLE
Fix Scoping bug

### DIFF
--- a/javascript/rest-nextjs/pages/p/[id].jsx
+++ b/javascript/rest-nextjs/pages/p/[id].jsx
@@ -66,7 +66,7 @@ export const getServerSideProps = async (context) => {
     where: { id: Number(context.params.id) },
     include: { author: true },
   })
-  return { props: { post } }
+  return { props: post }
 }
 
 export default Post


### PR DESCRIPTION
Fixes the scoping bug in props under the javascript nextjs example, which is causing the entire page (http://localhost:3000/p/1) to not read the data correctly.

This is the bug (happens when you click on any blog post or draft):

![image](https://user-images.githubusercontent.com/68541293/223074204-ecb2a561-debb-40fc-84a8-d8dbc09c5e74.png)
