### PR TITLE
fix #4983

### DIFF
--- a/typescript/graphql-nextjs/.gitignore
+++ b/typescript/graphql-nextjs/.gitignore
@@ -1,3 +1,10 @@
 node_modules/
 src/generated/
 .next/
+
+# lock files
+*lock.*
+*.lock
+
+# db
+*.db*

--- a/typescript/graphql-nextjs/package.json
+++ b/typescript/graphql-nextjs/package.json
@@ -33,5 +33,10 @@
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"
+  },
+  "pkg": {
+    "assets": [
+      "node_modules/.prisma/client/*.node"
+    ]
   }
 }


### PR DESCRIPTION
Fix #4983 - 

Fix error `Error: spawn prisma-pothos-types ENOENT` while running `pnpx prisma migrate dev --name init`