### PR TITLE
fix: Drafts is not set as the default export

### DIFF
--- a/typescript/rest-nextjs-api-routes/src/app/drafts/page.tsx
+++ b/typescript/rest-nextjs-api-routes/src/app/drafts/page.tsx
@@ -3,7 +3,7 @@ import Post from '../../components/Post'
 import prisma from '../../lib/prisma'
 import styles from '../../styles/Drafts.module.css'
 
-export async function Drafts() {
+export default async function Drafts() {
   const drafts = await prisma.post.findMany({
     where: { published: false },
     include: { author: true },


### PR DESCRIPTION
The Drafts page does not have export set causing an error when routing to that page