### PR TITLE
ci(renovate): Enable config migration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,7 @@
   "rangeStrategy": "pin",
   "baseBranches": ["latest"],
   "reviewers": ["ruheni", "jharrell"],
+  "configMigration": true,
   "packageRules": [
     {
       "baseBranchList": ["latest"],


### PR DESCRIPTION
With this configuration Renovate should open PRs to improve the configuration itself, so that we never use outdated keys or similar (as we do right now with packageNames, which was migrated to matchPackageNames)

see [docs.renovatebot.com/configuration-options/#configmigration](https://docs.renovatebot.com/configuration-options/#configmigration)