### PR TITLE
add teable

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The projects in the [`deployment-platforms`](./deployment-platforms) directory s
 - [Dundring](https://github.com/sivertschou/dundring): An in-browser training application created to control and track you training with a smart bike trainer
 - [Expense.fyi](https://github.com/gokulkrishh/expense.fyi): A tool for tracking and managing expenses
 - [Letterpad](https://github.com/letterpad/letterpad): A publishing platform for creatives
-
+- [Teable](https://github.com/teableio/teable): A no-code real-time database built on Postgres with a simple interface for enterprise-level app development.
 <hr>
 
 ## Starter kits


### PR DESCRIPTION
Adding [Teable](https://github.com/teableio/teable) to Prisma real-world OSS.