### PR TITLE
chore(typescript/rest-nestjs): remove unused dependency

### DIFF
--- a/typescript/rest-nestjs/src/prisma.service.ts
+++ b/typescript/rest-nestjs/src/prisma.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnModuleInit, INestApplication } from '@nestjs/common'
+import { Injectable, OnModuleInit } from '@nestjs/common'
 import { PrismaClient } from '@prisma/client'
 
 @Injectable()


### PR DESCRIPTION
Resolves #5805 

### AS-IS
```ts
import { Injectable, OnModuleInit, INestApplication } from '@nestjs/common' // `INestApplication` unused !
import { PrismaClient } from '@prisma/client'

@Injectable()
export class PrismaService extends PrismaClient implements OnModuleInit {
  async onModuleInit() {
    // Note: this is optional
    await this.$connect()
  }
}
```

### TO-BE
```ts
import { Injectable, OnModuleInit } from '@nestjs/common' 
import { PrismaClient } from '@prisma/client'

@Injectable()
export class PrismaService extends PrismaClient implements OnModuleInit {
  async onModuleInit() {
    // Note: this is optional
    await this.$connect()
  }
}
```