### PR TITLE
feat(generator-prisma-client): add Deno Deploy example

### DIFF
--- a/generator-prisma-client/deno-deploy/.env.example
+++ b/generator-prisma-client/deno-deploy/.env.example
@@ -1,0 +1,2 @@
+DIRECT_URL="postgres://..."
+DATABASE_URL="prisma+postgres://..."

--- a/generator-prisma-client/deno-deploy/.gitignore
+++ b/generator-prisma-client/deno-deploy/.gitignore
@@ -1,0 +1,1 @@
+src/generated/

--- a/generator-prisma-client/deno-deploy/README.md
+++ b/generator-prisma-client/deno-deploy/README.md
@@ -1,0 +1,112 @@
+# Prisma Postgres Example: Deno Deploy (Deno 2, ESM)
+
+This project showcases how to use the Prisma ORM with Prisma Postgres in an ESM Deno Deploy application.
+
+## Prerequisites
+
+To successfully run the project, you will need the following:
+
+- Two **Prisma Postgres** connection strings:
+  - Your **Prisma Postgres + Accelerate connection string** (containing your **Prisma API key**) which you can get by enabling Postgres in a project in your [Prisma Data Platform](https://pris.ly/pdp) account. You will use this connection string to run Prisma migrations.
+  - Your **Prisma Postgres direct TCP connection string** which you will use with Prisma Client.
+    Learn more in the [docs](https://www.prisma.io/docs/postgres/database/direct-connections).
+
+## Tech Stack
+
+- Deno 2
+- ESM
+- Prisma Client with the `prisma-client` generator
+  See the [Prisma schema file](./prisma/schema.prisma) for details.
+  
+  ```prisma
+  generator client {
+    provider = "prisma-client"
+    output = "../src/generated/prisma"
+    previewFeatures = ["driverAdapters", "queryCompiler"]
+    runtime = "deno"
+  }
+  ```
+
+## Getting started
+
+### 1. Clone the repository
+
+Clone the repository, navigate into it and install dependencies:
+
+```
+git clone git@github.com:prisma/prisma-examples.git --depth=1
+cd prisma-examples/generator-prisma-client/deno-deploy
+pnpm install
+```
+
+### 2. Configure environment variables
+
+Create a `.env` in the root of the project directory:
+
+```bash
+touch .env
+```
+
+Now, open the `.env` file and set the `DATABASE_URL` environment variables with the values of your connection string and your Prisma Postgres connection string:
+
+```bash
+# .env
+
+# Prisma Postgres connection string (used for migrations)
+DATABASE_URL="__YOUR_PRISMA_POSTGRES_CONNECTION_STRING__"
+
+# Postgres connection string (used for queries by Prisma Client)
+DIRECT_URL="__YOUR_PRISMA_POSTGRES_DIRECT_CONNECTION_STRING__"
+```
+
+Note that `__YOUR_PRISMA_POSTGRES_CONNECTION_STRING__` is a placeholder value that you need to replace with the values of your Prisma Postgres + Accelerate connection string. Notice that the Accelerate connection string has the following structure: `prisma+postgres://accelerate.prisma-data.net/?api_key=<api_key_value>`.
+
+Note that `__YOUR_PRISMA_POSTGRES_DIRECT_CONNECTION_STRING__` is a placeholder value that you need to replace with the values of your Prisma Postgres direct TCP connection string. The direct connection string has the following structure: `postgres://<username>:<password>@<host>:<port>/<database>`.
+
+### 3. Run a migration to create the database structure and seed the database
+
+The [Prisma schema file](./prisma/schema.prisma) contains a single `Quotes` model and a `QuoteKind` enum. You can map this model to the database and create the corresponding `Quotes` table using the following command:
+
+```
+deno task prisma migrate dev --name init
+```
+
+You now have an empty `Quotes` table in your database. Next, run the [seed script](./prisma/seed.ts) to create some sample records in the table:
+
+```
+deno run --allow-all --env-file=.env ./prisma/seed.ts
+```
+
+### 4. Generate Prisma Client
+
+Run:
+
+```
+deno task prisma generate
+```
+
+### 5. Start the app
+
+You can run the app with the following command:
+
+```
+deno task dev
+```
+
+### 6. Deploy to Deno Deploy
+
+To deploy your application to Deno Deploy, follow these steps:
+
+```
+deno install -gArf jsr:@deno/deployctl
+deployctl deploy --project=prisma-client-deno-deploy --env-file=.env
+```
+
+## Resources
+
+- [Prisma Postgres documentation](https://www.prisma.io/docs/postgres)
+- Check out the [Prisma docs](https://www.prisma.io/docs)
+- [Join our community on Discord](https://pris.ly/discord?utm_source=github&utm_medium=prisma_examples&utm_content=next_steps_section) to share feedback and interact with other users.
+- [Subscribe to our YouTube channel](https://pris.ly/youtube?utm_source=github&utm_medium=prisma_examples&utm_content=next_steps_section) for live demos and video tutorials.
+- [Follow us on X](https://pris.ly/x?utm_source=github&utm_medium=prisma_examples&utm_content=next_steps_section) for the latest updates.
+- Report issues or ask [questions on GitHub](https://pris.ly/github?utm_source=github&utm_medium=prisma_examples&utm_content=next_steps_section).

--- a/generator-prisma-client/deno-deploy/README.md
+++ b/generator-prisma-client/deno-deploy/README.md
@@ -36,7 +36,7 @@ Clone the repository, navigate into it and install dependencies:
 ```
 git clone git@github.com:prisma/prisma-examples.git --depth=1
 cd prisma-examples/generator-prisma-client/deno-deploy
-pnpm install
+deno install
 ```
 
 ### 2. Configure environment variables

--- a/generator-prisma-client/deno-deploy/deno.jsonc
+++ b/generator-prisma-client/deno-deploy/deno.jsonc
@@ -1,5 +1,6 @@
 {
   "name": "generator-prisma-client-deno-deploy",
+  "exports": "./src/main.ts",
   "tasks": {
     "dev": "deno serve --allow-env --allow-sys --allow-read --allow-net --env-file=.env ./src/main.ts",
     "prisma": "prisma",

--- a/generator-prisma-client/deno-deploy/deno.jsonc
+++ b/generator-prisma-client/deno-deploy/deno.jsonc
@@ -1,0 +1,17 @@
+{
+  "name": "generator-prisma-client-deno-deploy",
+  "tasks": {
+    "dev": "deno serve --allow-env --allow-sys --allow-read --allow-net --env-file=.env ./src/main.ts",
+    "prisma": "prisma",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate deploy"
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/http": "jsr:@std/http@1",
+    "@prisma/adapter-pg": "npm:@prisma/adapter-pg@6.11.0",
+    "@prisma/client": "npm:@prisma/client@6.11.0",
+    "prisma": "npm:prisma@6.11.0"
+  },
+  "nodeModulesDir": "auto"
+}

--- a/generator-prisma-client/deno-deploy/deno.lock
+++ b/generator-prisma-client/deno-deploy/deno.lock
@@ -1,0 +1,231 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.13",
+    "jsr:@std/cli@^1.0.20": "1.0.20",
+    "jsr:@std/encoding@^1.0.10": "1.0.10",
+    "jsr:@std/fmt@^1.0.8": "1.0.8",
+    "jsr:@std/fs@^1.0.19": "1.0.19",
+    "jsr:@std/html@^1.0.4": "1.0.4",
+    "jsr:@std/http@1": "1.0.19",
+    "jsr:@std/internal@^1.0.6": "1.0.9",
+    "jsr:@std/internal@^1.0.9": "1.0.9",
+    "jsr:@std/media-types@^1.1.0": "1.1.0",
+    "jsr:@std/net@^1.0.4": "1.0.4",
+    "jsr:@std/path@^1.1.1": "1.1.1",
+    "jsr:@std/streams@^1.0.10": "1.0.10",
+    "npm:@prisma/adapter-pg@6.11.0": "6.11.0",
+    "npm:@prisma/client@6.11.0": "6.11.0_prisma@6.11.0",
+    "npm:prisma@6.11.0": "6.11.0"
+  },
+  "jsr": {
+    "@std/assert@1.0.13": {
+      "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.6"
+      ]
+    },
+    "@std/cli@1.0.20": {
+      "integrity": "a8c384a2c98cec6ec6a2055c273a916e2772485eb784af0db004c5ab8ba52333"
+    },
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
+    },
+    "@std/fmt@1.0.8": {
+      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
+    },
+    "@std/fs@1.0.19": {
+      "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06"
+    },
+    "@std/html@1.0.4": {
+      "integrity": "eff3497c08164e6ada49b7f81a28b5108087033823153d065e3f89467dd3d50e"
+    },
+    "@std/http@1.0.19": {
+      "integrity": "52128c8d00a1f0b20019f8b72376e7ef5f3133375b6f805b5bc89b9de2ad4686",
+      "dependencies": [
+        "jsr:@std/cli",
+        "jsr:@std/encoding",
+        "jsr:@std/fmt",
+        "jsr:@std/fs",
+        "jsr:@std/html",
+        "jsr:@std/media-types",
+        "jsr:@std/net",
+        "jsr:@std/path",
+        "jsr:@std/streams"
+      ]
+    },
+    "@std/internal@1.0.9": {
+      "integrity": "bdfb97f83e4db7a13e8faab26fb1958d1b80cc64366501af78a0aee151696eb8"
+    },
+    "@std/media-types@1.1.0": {
+      "integrity": "c9d093f0c05c3512932b330e3cc1fe1d627b301db33a4c2c2185c02471d6eaa4"
+    },
+    "@std/net@1.0.4": {
+      "integrity": "2f403b455ebbccf83d8a027d29c5a9e3a2452fea39bb2da7f2c04af09c8bc852"
+    },
+    "@std/path@1.1.1": {
+      "integrity": "fe00026bd3a7e6a27f73709b83c607798be40e20c81dde655ce34052fd82ec76",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.9"
+      ]
+    },
+    "@std/streams@1.0.10": {
+      "integrity": "75c0b1431873cd0d8b3d679015220204d36d3c7420d93b60acfc379eb0dc30af"
+    }
+  },
+  "npm": {
+    "@prisma/adapter-pg@6.11.0": {
+      "integrity": "sha512-FMZwHoF54WVZT/26dQmk8Gbsud/JeHUny+POvaN0Aztr+eomycNOo/dHefU+nCm+fBI/vuwlAaCAAtPkeC+m2w==",
+      "dependencies": [
+        "@prisma/driver-adapter-utils",
+        "pg",
+        "postgres-array@3.0.4"
+      ]
+    },
+    "@prisma/client@6.11.0_prisma@6.11.0": {
+      "integrity": "sha512-K9TkKepOYvCOg3qCuKz7ZHf6rf58BFKi08plKjU4qVv9y7/UxO6tLz7PlWcgODUZKURLPmRHjHERffIx/8az4w==",
+      "dependencies": [
+        "prisma"
+      ],
+      "optionalPeers": [
+        "prisma"
+      ],
+      "scripts": true
+    },
+    "@prisma/config@6.11.0": {
+      "integrity": "sha512-icBfutMpdrwSf2ggo012zhQ4oianijXL/UPbv4PNVK3WUWbB3/F5Ltq8ZfElGrtwKC6XuFFPxU5qDC9x7vh8zQ==",
+      "dependencies": [
+        "jiti"
+      ]
+    },
+    "@prisma/debug@6.11.0": {
+      "integrity": "sha512-zo4oEZMWMt0BFWl+4NK9FUpaEOmjGR3y2/r0lkW/DK4BUBRgMj90s8QqK2K+vXG3xn0nAGg2kOSu+Swn60CFLg=="
+    },
+    "@prisma/driver-adapter-utils@6.11.0": {
+      "integrity": "sha512-fuXpLkhHxY2x7/i1IylscOgmaKdMtvalumSBaTkJ2z3LG0Z/+px6aP3lKBGU6NVX5FrCnrTlK+dxifJaWzPJrA==",
+      "dependencies": [
+        "@prisma/debug"
+      ]
+    },
+    "@prisma/engines-version@6.11.0-18.9c30299f5a0ea26a96790e13f796dc6094db3173": {
+      "integrity": "sha512-M3vbyDICFIA1oJl0cFkM0omD4HsJZjFi0hu0f0UxyPABH8KEcZyUd5BToCrNl4B8lUeQn+L5+gfaQleOKp6Lrg=="
+    },
+    "@prisma/engines@6.11.0": {
+      "integrity": "sha512-uqnYxvPKZPvYZA7F0q4gTR+fVWUJSY5bif7JAKBIOD5SoRRy0qEIaPy4Nna5WDLQaFGshaY/Bh8dLOQMfxhJJw==",
+      "dependencies": [
+        "@prisma/debug",
+        "@prisma/engines-version",
+        "@prisma/fetch-engine",
+        "@prisma/get-platform"
+      ],
+      "scripts": true
+    },
+    "@prisma/fetch-engine@6.11.0": {
+      "integrity": "sha512-ZHHSP7vJFo5hePH+MNovxhqXabIg38ZpCwQfUBON29kwPX3f1pjYnzGpgJLCJy4k7mKGOzTgrXPqH8+nJvq2fw==",
+      "dependencies": [
+        "@prisma/debug",
+        "@prisma/engines-version",
+        "@prisma/get-platform"
+      ]
+    },
+    "@prisma/get-platform@6.11.0": {
+      "integrity": "sha512-yspBGvOfJQwuoApk5B4aBlHDy6YDXAOe4Ml8U2eZ+M2b7fDd10YDomS3Q4qrYHUUVYF3TJyN86NcnRMOvCMUrA==",
+      "dependencies": [
+        "@prisma/debug"
+      ]
+    },
+    "jiti@2.4.2": {
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "bin": true
+    },
+    "pg-cloudflare@1.2.7": {
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg=="
+    },
+    "pg-connection-string@2.9.1": {
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w=="
+    },
+    "pg-int8@1.0.1": {
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-pool@3.10.1_pg@8.16.3": {
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "dependencies": [
+        "pg"
+      ]
+    },
+    "pg-protocol@1.10.3": {
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ=="
+    },
+    "pg-types@2.2.0": {
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": [
+        "pg-int8",
+        "postgres-array@2.0.0",
+        "postgres-bytea",
+        "postgres-date",
+        "postgres-interval"
+      ]
+    },
+    "pg@8.16.3": {
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "dependencies": [
+        "pg-connection-string",
+        "pg-pool",
+        "pg-protocol",
+        "pg-types",
+        "pgpass"
+      ],
+      "optionalDependencies": [
+        "pg-cloudflare"
+      ]
+    },
+    "pgpass@1.0.5": {
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dependencies": [
+        "split2"
+      ]
+    },
+    "postgres-array@2.0.0": {
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-array@3.0.4": {
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ=="
+    },
+    "postgres-bytea@1.0.0": {
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
+    },
+    "postgres-date@1.0.7": {
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval@1.2.0": {
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": [
+        "xtend"
+      ]
+    },
+    "prisma@6.11.0": {
+      "integrity": "sha512-gI69E7fusgk32XALpXzdgR10xUx2aFnHiu/JaUo4O07G4JvFT0xNtD0Iy81p37iBLTYFEhWa9VrHKXaiyZ5fLQ==",
+      "dependencies": [
+        "@prisma/config",
+        "@prisma/engines"
+      ],
+      "scripts": true,
+      "bin": true
+    },
+    "split2@4.2.0": {
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+    },
+    "xtend@4.0.2": {
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@1",
+      "jsr:@std/http@1",
+      "npm:@prisma/adapter-pg@6.11.0",
+      "npm:@prisma/client@6.11.0",
+      "npm:prisma@6.11.0"
+    ]
+  }
+}

--- a/generator-prisma-client/deno-deploy/prisma/schema.prisma
+++ b/generator-prisma-client/deno-deploy/prisma/schema.prisma
@@ -1,0 +1,24 @@
+generator client {
+  provider = "prisma-client"
+  output = "../src/generated/prisma"
+  previewFeatures = ["driverAdapters", "queryCompiler"]
+  runtime = "deno"
+}
+
+datasource db {
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
+}
+
+enum QuoteKind {
+  Fact
+  Opinion
+}
+
+model Quotes {
+  id        Int      @id @default(autoincrement())
+  quote     String
+  kind      QuoteKind @default(Opinion)
+  createdAt DateTime @default(now())
+}

--- a/generator-prisma-client/deno-deploy/prisma/seed.ts
+++ b/generator-prisma-client/deno-deploy/prisma/seed.ts
@@ -1,0 +1,155 @@
+import { getDb } from '../src/db.ts'
+import { QuoteKind } from '../src/prisma-enums.ts'
+
+const main = async () => {
+  console.log('Seeding database...')
+  
+  if (!Deno.env.get("DIRECT_URL")) {
+    throw new Error("DIRECT_URL environment variable is not set");
+  }
+
+  const prisma = getDb({ connectionString: Deno.env.get("DIRECT_URL")! })
+
+  console.time('Seeding complete 🌱')
+
+  await prisma.quotes.deleteMany()
+
+  await prisma.quotes.createMany({
+    skipDuplicates: true,
+    data: [
+      {
+        quote: 'The only way to do great work is to love what you do.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote:
+          'Success is not final, failure is not fatal: It is the courage to continue that counts.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'In the middle of every difficulty lies opportunity.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: "Believe you can and you're halfway there.",
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'The best way to predict the future is to create it.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: "Don't watch the clock; do what it does. Keep going.",
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'The only thing we have to fear is fear itself.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'The journey of a thousand miles begins with a single step.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'If you can dream it, you can achieve it.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'Innovation distinguishes between a leader and a follower.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote:
+          'The greatest glory in living lies not in never falling, but in rising every time we fall.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: "You miss 100% of the shots you don't take.",
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote:
+          'The only limit to our realization of tomorrow will be our doubts of today.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'Change your thoughts and you change your world.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote:
+          'To be yourself in a world that is constantly trying to make you something else is the greatest accomplishment.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote:
+          "The only thing standing between you and your goal is the story you keep telling yourself as to why you can't achieve it.",
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'Life is 10% what happens to us and 90% how we react to it.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote:
+          'The future belongs to those who believe in the beauty of their dreams.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote:
+          'Do not wait for the perfect moment, take the moment and make it perfect.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'The only source of knowledge is experience.',
+        kind: QuoteKind.Opinion,
+      },
+
+      // Facts
+      {
+        quote: 'Honey never spoils and can last thousands of years.',
+        kind: QuoteKind.Fact,
+      },
+      {
+        quote: 'Bananas are berries, but strawberries are not.',
+        kind: QuoteKind.Fact,
+      },
+      { quote: 'Octopuses have three hearts.', kind: QuoteKind.Fact },
+      {
+        quote: "A group of flamingos is called a 'flamboyance'.",
+        kind: QuoteKind.Fact,
+      },
+      {
+        quote: 'Humans share 60% of their DNA with bananas.',
+        kind: QuoteKind.Fact,
+      },
+      {
+        quote: 'The Eiffel Tower can be 15 cm taller during hot days.',
+        kind: QuoteKind.Fact,
+      },
+      { quote: 'Wombat poop is cube-shaped.', kind: QuoteKind.Fact },
+      {
+        quote:
+          'Some metals are so reactive that they explode on contact with water.',
+        kind: QuoteKind.Fact,
+      },
+      {
+        quote:
+          'There are more stars in the universe than grains of sand on Earth.',
+        kind: QuoteKind.Fact,
+      },
+      {
+        quote: 'Venus is the only planet that spins clockwise.',
+        kind: QuoteKind.Fact,
+      },
+    ],
+  })
+
+  console.timeEnd('Seeding complete 🌱')
+}
+
+main()
+  .then(() => {
+    console.log('Process completed')
+  })
+  .catch((e) => console.log(e))

--- a/generator-prisma-client/deno-deploy/src/db.ts
+++ b/generator-prisma-client/deno-deploy/src/db.ts
@@ -1,0 +1,13 @@
+import { PrismaPg } from '@prisma/adapter-pg'
+import { PrismaClient } from './generated/prisma/client.ts'
+
+export type GetDbParams = {
+  connectionString: string
+}
+
+export function getDb({ connectionString }: GetDbParams) {
+  const pool = new PrismaPg({ connectionString })
+  const prisma = new PrismaClient({ adapter: pool })
+
+  return prisma
+}

--- a/generator-prisma-client/deno-deploy/src/main.ts
+++ b/generator-prisma-client/deno-deploy/src/main.ts
@@ -1,0 +1,21 @@
+import { getDb } from "./db.ts";
+
+export default {
+  async fetch(req) {
+    if (req.method !== "GET") {
+      return new Response("Method Not Allowed", { status: 405 });
+    }
+
+    if (!Deno.env.get("DIRECT_URL")) {
+      return new Response("DIRECT_URL environment variable is not set", { status: 500 });
+    }
+
+    const prisma = getDb({
+      connectionString: Deno.env.get("DIRECT_URL")!,
+    });
+
+    const quotes = await prisma.quotes.findMany({})
+
+    return Response.json({ data: quotes });
+  },
+} satisfies Deno.ServeDefaultExport;

--- a/generator-prisma-client/deno-deploy/src/prisma-enums.ts
+++ b/generator-prisma-client/deno-deploy/src/prisma-enums.ts
@@ -1,0 +1,1 @@
+export * from "./generated/prisma/enums.ts";


### PR DESCRIPTION
This PR adds new starter demo project `generator-prisma-client/deno-deploy` using Prisma Postgres + the new ESM-compatible `prisma-client` generator.

- **Framework**: None
- **Bundler**: None
- **Runtime**: Deno 2
- **Ticket**: [ORM-1081](https://linear.app/prisma-company/issue/ORM-1081/provide-demo-example-of-deno-deploy-prisma-client)
- Worked out of the box: Yes.