### PR TITLE
feat(generator-prisma-client): add esbuild-cjs example

### DIFF
--- a/generator-prisma-client/esbuild-cjs/.gitignore
+++ b/generator-prisma-client/esbuild-cjs/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+src/generated
+dist

--- a/generator-prisma-client/esbuild-cjs/README.md
+++ b/generator-prisma-client/esbuild-cjs/README.md
@@ -1,0 +1,134 @@
+# Prisma Postgres Example: ESBuild + Node.js + CJS
+
+This project showcases how to use the Prisma ORM with Prisma Postgres in an TypeScript application transpiled to CommonJS (CJS) using ESBuild.
+
+## Prerequisites
+
+To successfully run the project, you will need the following:
+
+- Two **Prisma Postgres** connection strings:
+  - Your **Prisma Postgres + Accelerate connection string** (containing your **Prisma API key**) which you can get by enabling Postgres in a project in your [Prisma Data Platform](https://pris.ly/pdp) account. You will use this connection string to run Prisma migrations.
+  - Your **Prisma Postgres direct TCP connection string** which you will use with Prisma Client.
+    Learn more in the [docs](https://www.prisma.io/docs/postgres/database/direct-connections).
+
+## Tech Stack
+
+- Next.js 15
+  - Runtime: Node.js 20.19.0
+  - Bundler: Turbopack (stable for `dev`, alpha for `build`)
+- CJS
+  - `package.json` contains `{ "type": "commonjs" }`
+  - `esbuild` specifies `format: 'cjs'`
+- Prisma Client with the `prisma-client` generator
+  See the [Prisma schema file](./prisma/schema.prisma) for details.
+  
+  ```prisma
+  generator client {
+    provider = "prisma-client"
+    output = "../src/generated/prisma"
+    previewFeatures = ["driverAdapters", "queryCompiler"]
+    moduleFormat = "cjs"
+  }
+
+  datasource db {
+    provider  = "postgresql"
+    url       = env("DATABASE_URL")
+    directUrl = env("DIRECT_URL")
+  }
+  ```
+
+## Getting started
+
+### 1. Clone the repository
+
+Clone the repository, navigate into it and install dependencies:
+
+```
+git clone git@github.com:prisma/prisma-examples.git --depth=1
+cd prisma-examples/generator-prisma-client/esbuild-cjs
+pnpm install
+```
+
+### 2. Configure environment variables
+
+Create a `.env` in the root of the project directory:
+
+```bash
+touch .env
+```
+
+Now, open the `.env` file and set the `DATABASE_URL` environment variables with the values of your connection string and your Prisma Postgres connection string:
+
+```bash
+# .env
+
+# Prisma Postgres connection string (used for migrations)
+DATABASE_URL="__YOUR_PRISMA_POSTGRES_CONNECTION_STRING__"
+
+# Postgres connection string (used for queries by Prisma Client)
+DIRECT_URL="__YOUR_PRISMA_POSTGRES_DIRECT_CONNECTION_STRING__"
+
+NEXT_PUBLIC_URL="http://localhost:3000"
+```
+
+Note that `__YOUR_PRISMA_POSTGRES_CONNECTION_STRING__` is a placeholder value that you need to replace with the values of your Prisma Postgres + Accelerate connection string. Notice that the Accelerate connection string has the following structure: `prisma+postgres://accelerate.prisma-data.net/?api_key=<api_key_value>`.
+
+Note that `__YOUR_PRISMA_POSTGRES_DIRECT_CONNECTION_STRING__` is a placeholder value that you need to replace with the values of your Prisma Postgres direct TCP connection string. The direct connection string has the following structure: `postgres://<username>:<password>@<host>:<port>/<database>`.
+
+### 3. Run a migration to create the database structure and seed the database
+
+The [Prisma schema file](./prisma/schema.prisma) contains a single `Quotes` model and a `QuoteKind` enum. You can map this model to the database and create the corresponding `Quotes` table using the following command:
+
+```
+pnpm prisma migrate dev --name init
+```
+
+You now have an empty `Quotes` table in your database. Next, run the [seed script](./prisma/seed.ts) to create some sample records in the table:
+
+```
+pnpm prisma db seed
+```
+
+### 4. Generate Prisma Client
+
+Run:
+
+```
+pnpm prisma generate
+```
+
+### 5. Bundle the project
+
+Run
+
+```
+pnpm bundle
+```
+
+### 6. Run
+
+We offer two possible entry points to run this project:
+
+- Spawn a Hono HTTP Server that queries the database via Prisma Client:
+  ```
+  node ./dist/hono.cjs
+  ```
+
+  In another terminal, you can run the following command to test the server:
+
+  ```
+  curl -X GET "http://localhost:3000/quotes"
+  ```
+- Run a minimal script that queries the database via Prisma Client:
+  ```
+  node -r dotenv/config ./dist/minimal.cjs
+  ```
+
+## Resources
+
+- [Prisma Postgres documentation](https://www.prisma.io/docs/postgres)
+- Check out the [Prisma docs](https://www.prisma.io/docs)
+- [Join our community on Discord](https://pris.ly/discord?utm_source=github&utm_medium=prisma_examples&utm_content=next_steps_section) to share feedback and interact with other users.
+- [Subscribe to our YouTube channel](https://pris.ly/youtube?utm_source=github&utm_medium=prisma_examples&utm_content=next_steps_section) for live demos and video tutorials.
+- [Follow us on X](https://pris.ly/x?utm_source=github&utm_medium=prisma_examples&utm_content=next_steps_section) for the latest updates.
+- Report issues or ask [questions on GitHub](https://pris.ly/github?utm_source=github&utm_medium=prisma_examples&utm_content=next_steps_section).

--- a/generator-prisma-client/esbuild-cjs/esbuild.cjs.ts
+++ b/generator-prisma-client/esbuild-cjs/esbuild.cjs.ts
@@ -1,0 +1,25 @@
+import esbuild, { type BuildOptions } from 'esbuild'
+
+const buildOpts = {
+  bundle: true,
+  sourcemap: true,
+  entryPoints: ['./src/hono.ts', './src/minimal.ts'],
+  outdir: './dist',
+  outExtension: {
+    '.js': '.cjs',
+  },
+  format: 'cjs',
+  target: 'es2022',
+  platform: 'node',
+  
+  // To make it work with Prisma 6.11, you would need to use the following condition:
+  // ```
+  // conditions: ['require']
+  // ```
+} satisfies BuildOptions
+
+async function build() {
+  await esbuild.build(buildOpts);
+}
+
+build()

--- a/generator-prisma-client/esbuild-cjs/package.json
+++ b/generator-prisma-client/esbuild-cjs/package.json
@@ -26,5 +26,8 @@
     "rimraf": "^6.0.1",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
   }
 }

--- a/generator-prisma-client/esbuild-cjs/package.json
+++ b/generator-prisma-client/esbuild-cjs/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "esbuild-cjs",
+  "type": "commonjs",
+  "scripts": {
+    "bundle": "tsx ./esbuild.cjs.ts",
+    "prisma:generate": "prisma generate",
+    "clean": "rimraf ./src/generated ./dist",
+    "start:hono": "node -r dotenv/config ./dist/minimal.cjs",
+    "start:minimal": "node -r dotenv/config ./dist/minimal.cjs",
+    "dev:hono": "tsx -r dotenv/config ./src/hono.ts",
+    "dev:minimal": "tsx -r dotenv/config ./src/minimal.ts"
+  },
+  "license": "MIT",
+  "packageManager": "pnpm@8.15.9+sha512.499434c9d8fdd1a2794ebf4552b3b25c0a633abcee5bb15e7b5de90f32f47b513aca98cd5cfd001c31f0db454bc3804edccd578501e4ca293a6816166bbd9f81",
+  "dependencies": {
+    "@hono/node-server": "^1.15.0",
+    "@prisma/adapter-pg": "6.12.0-dev.19",
+    "@prisma/client": "6.12.0-dev.19",
+    "hono": "^4.8.4"
+  },
+  "devDependencies": {
+    "@types/node": "^18.19.117",
+    "dotenv": "^17.1.0",
+    "esbuild": "^0.25.6",
+    "prisma": "6.12.0-dev.19",
+    "rimraf": "^6.0.1",
+    "tsx": "^4.20.3",
+    "typescript": "^5.8.3"
+  }
+}

--- a/generator-prisma-client/esbuild-cjs/pnpm-lock.yaml
+++ b/generator-prisma-client/esbuild-cjs/pnpm-lock.yaml
@@ -1,0 +1,791 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  '@hono/node-server':
+    specifier: ^1.15.0
+    version: 1.15.0(hono@4.8.4)
+  '@prisma/adapter-pg':
+    specifier: 6.12.0-dev.19
+    version: 6.12.0-dev.19
+  '@prisma/client':
+    specifier: 6.12.0-dev.19
+    version: 6.12.0-dev.19(prisma@6.12.0-dev.19)(typescript@5.8.3)
+  hono:
+    specifier: ^4.8.4
+    version: 4.8.4
+
+devDependencies:
+  '@types/node':
+    specifier: ^18.19.117
+    version: 18.19.117
+  dotenv:
+    specifier: ^17.1.0
+    version: 17.1.0
+  esbuild:
+    specifier: ^0.25.6
+    version: 0.25.6
+  prisma:
+    specifier: 6.12.0-dev.19
+    version: 6.12.0-dev.19(typescript@5.8.3)
+  rimraf:
+    specifier: ^6.0.1
+    version: 6.0.1
+  tsx:
+    specifier: ^4.20.3
+    version: 4.20.3
+  typescript:
+    specifier: ^5.8.3
+    version: 5.8.3
+
+packages:
+
+  /@esbuild/aix-ppc64@0.25.6:
+    resolution: {integrity: sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.25.6:
+    resolution: {integrity: sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.25.6:
+    resolution: {integrity: sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.25.6:
+    resolution: {integrity: sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.25.6:
+    resolution: {integrity: sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.25.6:
+    resolution: {integrity: sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.25.6:
+    resolution: {integrity: sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.25.6:
+    resolution: {integrity: sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.25.6:
+    resolution: {integrity: sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.25.6:
+    resolution: {integrity: sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.25.6:
+    resolution: {integrity: sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.25.6:
+    resolution: {integrity: sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.25.6:
+    resolution: {integrity: sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.25.6:
+    resolution: {integrity: sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.25.6:
+    resolution: {integrity: sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.25.6:
+    resolution: {integrity: sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.25.6:
+    resolution: {integrity: sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-arm64@0.25.6:
+    resolution: {integrity: sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.25.6:
+    resolution: {integrity: sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.25.6:
+    resolution: {integrity: sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.25.6:
+    resolution: {integrity: sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openharmony-arm64@0.25.6:
+    resolution: {integrity: sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.25.6:
+    resolution: {integrity: sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.25.6:
+    resolution: {integrity: sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.25.6:
+    resolution: {integrity: sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.25.6:
+    resolution: {integrity: sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@hono/node-server@1.15.0(hono@4.8.4):
+    resolution: {integrity: sha512-MjmK4l5N4dQpZ9OSWN0tCj7ejuc7WvuWMzSKtc89bnknJykAeHxzRigXBTYZk85H6Awrii6RM59iUiUluApu2A==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+    dependencies:
+      hono: 4.8.4
+    dev: false
+
+  /@isaacs/balanced-match@4.0.1:
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+    dev: true
+
+  /@isaacs/brace-expansion@5.0.0:
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+    dev: true
+
+  /@isaacs/cliui@8.0.2:
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: /string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: /strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: /wrap-ansi@7.0.0
+    dev: true
+
+  /@prisma/adapter-pg@6.12.0-dev.19:
+    resolution: {integrity: sha512-S6MQCE/r7OYho+Od64ny4kUsd6UkIvBdo5D9i0SQgxuc2y3mpUnrbmRpWVoSn/RdhLMzTlHzWyETww2+q19o1w==}
+    dependencies:
+      '@prisma/driver-adapter-utils': 6.12.0-dev.19
+      pg: 8.16.3
+      postgres-array: 3.0.4
+    transitivePeerDependencies:
+      - pg-native
+    dev: false
+
+  /@prisma/client@6.12.0-dev.19(prisma@6.12.0-dev.19)(typescript@5.8.3):
+    resolution: {integrity: sha512-1lik7Ji+DQwdlX6FqKMvXLSmg4upUhbTDbczLH+VRsCVJlggx/T/uXFa/VObQtXmGUxkbRsDTaNoCneUwBESog==}
+    engines: {node: '>=18.18'}
+    requiresBuild: true
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      prisma: 6.12.0-dev.19(typescript@5.8.3)
+      typescript: 5.8.3
+    dev: false
+
+  /@prisma/config@6.12.0-dev.19:
+    resolution: {integrity: sha512-RGBtiYpuX74N90WcAgUJtYIZdwNBDh6Sro04dhyu4WO8bpi09VOFuvRxQg/OXDwLZpgPZfHOu2kwSnLI0iXJUg==}
+    dependencies:
+      jiti: 2.4.2
+
+  /@prisma/debug@6.12.0-dev.19:
+    resolution: {integrity: sha512-9noBPgS8uV1QfcMT3TUyD1+WTLVu8UyxonWxF8bkCRWYvng2t6fCH2xEUpp6h26SxZOY9MYJRkToz9n397FUfg==}
+
+  /@prisma/driver-adapter-utils@6.12.0-dev.19:
+    resolution: {integrity: sha512-YxSKIcxS2W5RsVsrbvsbjUnC0V4HXEuy0NudxxhL3kYBrePC/MGRJWwgBVVjwaj5H0xmCe6sTuVRZFYWnDC2Ag==}
+    dependencies:
+      '@prisma/debug': 6.12.0-dev.19
+    dev: false
+
+  /@prisma/engines-version@6.12.0-7.c238eea7bd55fe78a5fbd21d9119bee49f0ee79b:
+    resolution: {integrity: sha512-e7o9/FbZbFIFNRDruWAg9KXECPc5h3stpq+mz+ettXSFaRJU7ke4oECyB6Iyf5AGqTgzkyBumQYZGv0xy29uLg==}
+
+  /@prisma/engines@6.12.0-dev.19:
+    resolution: {integrity: sha512-gaFcPFt84ji2mgTVY7XgJrQADtNLFNXVmtWEj94BBhJC3GJV2UjVT9jVf2SUFBrMbbLkLQ9T1NmOCrQ9O7QAdA==}
+    requiresBuild: true
+    dependencies:
+      '@prisma/debug': 6.12.0-dev.19
+      '@prisma/engines-version': 6.12.0-7.c238eea7bd55fe78a5fbd21d9119bee49f0ee79b
+      '@prisma/fetch-engine': 6.12.0-dev.19
+      '@prisma/get-platform': 6.12.0-dev.19
+
+  /@prisma/fetch-engine@6.12.0-dev.19:
+    resolution: {integrity: sha512-aZoEeky4BlmvOwb1T9IlMR7bBFWbe0pSGk8SR/c+kkhhcqHOAA+7s9DUJYl1pXpssWPtKyCzDWxS5WbDQmfZ9Q==}
+    dependencies:
+      '@prisma/debug': 6.12.0-dev.19
+      '@prisma/engines-version': 6.12.0-7.c238eea7bd55fe78a5fbd21d9119bee49f0ee79b
+      '@prisma/get-platform': 6.12.0-dev.19
+
+  /@prisma/get-platform@6.12.0-dev.19:
+    resolution: {integrity: sha512-praxClv0gvk4ZTyYePZt/tv+osTwynK3tWIv1HXDNVBePND6Yf9gynqmFgwkkjpuRh5ekOZ0H2S6tnXrmiw64g==}
+    dependencies:
+      '@prisma/debug': 6.12.0-dev.19
+
+  /@types/node@18.19.117:
+    resolution: {integrity: sha512-hcxGs9TfQGghOM8atpRT+bBMUX7V8WosdYt98bQ59wUToJck55eCOlemJ+0FpOZOQw5ff7LSi9+IO56KvYEFyQ==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
+
+  /ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      color-convert: 2.0.1
+    dev: true
+
+  /ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: 1.1.4
+    dev: true
+
+  /color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: true
+
+  /cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+    dev: true
+
+  /dotenv@17.1.0:
+    resolution: {integrity: sha512-tG9VUTJTuju6GcXgbdsOuRhupE8cb4mRgY5JLRCh4MtGoVo3/gfGUtOMwmProM6d0ba2mCFvv+WrpYJV6qgJXQ==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    dev: true
+
+  /emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: true
+
+  /emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    dev: true
+
+  /esbuild@0.25.6:
+    resolution: {integrity: sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.6
+      '@esbuild/android-arm': 0.25.6
+      '@esbuild/android-arm64': 0.25.6
+      '@esbuild/android-x64': 0.25.6
+      '@esbuild/darwin-arm64': 0.25.6
+      '@esbuild/darwin-x64': 0.25.6
+      '@esbuild/freebsd-arm64': 0.25.6
+      '@esbuild/freebsd-x64': 0.25.6
+      '@esbuild/linux-arm': 0.25.6
+      '@esbuild/linux-arm64': 0.25.6
+      '@esbuild/linux-ia32': 0.25.6
+      '@esbuild/linux-loong64': 0.25.6
+      '@esbuild/linux-mips64el': 0.25.6
+      '@esbuild/linux-ppc64': 0.25.6
+      '@esbuild/linux-riscv64': 0.25.6
+      '@esbuild/linux-s390x': 0.25.6
+      '@esbuild/linux-x64': 0.25.6
+      '@esbuild/netbsd-arm64': 0.25.6
+      '@esbuild/netbsd-x64': 0.25.6
+      '@esbuild/openbsd-arm64': 0.25.6
+      '@esbuild/openbsd-x64': 0.25.6
+      '@esbuild/openharmony-arm64': 0.25.6
+      '@esbuild/sunos-x64': 0.25.6
+      '@esbuild/win32-arm64': 0.25.6
+      '@esbuild/win32-ia32': 0.25.6
+      '@esbuild/win32-x64': 0.25.6
+    dev: true
+
+  /foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+    dev: true
+
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    dev: true
+
+  /glob@11.0.3:
+    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.1.1
+      minimatch: 10.0.3
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
+    dev: true
+
+  /hono@4.8.4:
+    resolution: {integrity: sha512-KOIBp1+iUs0HrKztM4EHiB2UtzZDTBihDtOF5K6+WaJjCPeaW4Q92R8j63jOhvJI5+tZSMuKD9REVEXXY9illg==}
+    engines: {node: '>=16.9.0'}
+    dev: false
+
+  /is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: true
+
+  /jackspeak@4.1.1:
+    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
+    engines: {node: 20 || >=22}
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    dev: true
+
+  /jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
+  /lru-cache@11.1.0:
+    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+    engines: {node: 20 || >=22}
+    dev: true
+
+  /minimatch@10.0.3:
+    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
+    engines: {node: 20 || >=22}
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.0
+    dev: true
+
+  /minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dev: true
+
+  /package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+    dev: true
+
+  /path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
+    dependencies:
+      lru-cache: 11.1.0
+      minipass: 7.1.2
+    dev: true
+
+  /pg-cloudflare@1.2.7:
+    resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /pg-connection-string@2.9.1:
+    resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
+    dev: false
+
+  /pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+    dev: false
+
+  /pg-pool@3.10.1(pg@8.16.3):
+    resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
+    peerDependencies:
+      pg: '>=8.0'
+    dependencies:
+      pg: 8.16.3
+    dev: false
+
+  /pg-protocol@1.10.3:
+    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
+    dev: false
+
+  /pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+    dev: false
+
+  /pg@8.16.3:
+    resolution: {integrity: sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+    dependencies:
+      pg-connection-string: 2.9.1
+      pg-pool: 3.10.1(pg@8.16.3)
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.2.7
+    dev: false
+
+  /pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+    dependencies:
+      split2: 4.2.0
+    dev: false
+
+  /postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /postgres-bytea@1.0.0:
+    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      xtend: 4.0.2
+    dev: false
+
+  /prisma@6.12.0-dev.19(typescript@5.8.3):
+    resolution: {integrity: sha512-yEMZgS43ejfwoVLLx+p0aECvjMmVA8FHiX6xMrdTpXXuGGT9NhZOz2kMpC+AZTN15OioGQyw0lokRwUmxnSZkQ==}
+    engines: {node: '>=18.18'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@prisma/config': 6.12.0-dev.19
+      '@prisma/engines': 6.12.0-dev.19
+      typescript: 5.8.3
+
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
+  /rimraf@6.0.1:
+    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+    dependencies:
+      glob: 11.0.3
+      package-json-from-dist: 1.0.1
+    dev: true
+
+  /shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+    dependencies:
+      shebang-regex: 3.0.0
+    dev: true
+
+  /shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+    dev: true
+
+  /split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+    dev: false
+
+  /string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    dev: true
+
+  /string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+    dev: true
+
+  /strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-regex: 5.0.1
+    dev: true
+
+  /strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-regex: 6.1.0
+    dev: true
+
+  /tsx@4.20.3:
+    resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.25.6
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: true
+
+  /which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
+    dev: true
+
+  /wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: true
+
+  /wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+    dev: true
+
+  /xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+    dev: false

--- a/generator-prisma-client/esbuild-cjs/prisma/schema.prisma
+++ b/generator-prisma-client/esbuild-cjs/prisma/schema.prisma
@@ -1,0 +1,28 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+// See: https://www.prisma.io/docs/orm/prisma-schema/overview/generators#field-reference-1
+generator client {
+  provider = "prisma-client"
+  output = "../src/generated/prisma"
+  previewFeatures = ["driverAdapters", "queryCompiler"]
+  moduleFormat = "cjs"
+}
+
+datasource db {
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
+}
+
+enum QuoteKind {
+  Fact
+  Opinion
+}
+
+model Quotes {
+  id        Int      @id @default(autoincrement())
+  quote     String
+  kind      QuoteKind @default(Opinion)
+  createdAt DateTime @default(now())
+}

--- a/generator-prisma-client/esbuild-cjs/prisma/seed.ts
+++ b/generator-prisma-client/esbuild-cjs/prisma/seed.ts
@@ -1,0 +1,148 @@
+import prisma from '../src/db'
+import { QuoteKind } from '../src/prisma-enums'
+
+const main = async () => {
+  console.log('Seeding database...')
+  console.time('Seeding complete 🌱')
+
+  await prisma.quotes.deleteMany()
+
+  await prisma.quotes.createMany({
+    skipDuplicates: true,
+    data: [
+      {
+        quote: 'The only way to do great work is to love what you do.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote:
+          'Success is not final, failure is not fatal: It is the courage to continue that counts.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'In the middle of every difficulty lies opportunity.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: "Believe you can and you're halfway there.",
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'The best way to predict the future is to create it.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: "Don't watch the clock; do what it does. Keep going.",
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'The only thing we have to fear is fear itself.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'The journey of a thousand miles begins with a single step.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'If you can dream it, you can achieve it.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'Innovation distinguishes between a leader and a follower.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote:
+          'The greatest glory in living lies not in never falling, but in rising every time we fall.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: "You miss 100% of the shots you don't take.",
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote:
+          'The only limit to our realization of tomorrow will be our doubts of today.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'Change your thoughts and you change your world.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote:
+          'To be yourself in a world that is constantly trying to make you something else is the greatest accomplishment.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote:
+          "The only thing standing between you and your goal is the story you keep telling yourself as to why you can't achieve it.",
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'Life is 10% what happens to us and 90% how we react to it.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote:
+          'The future belongs to those who believe in the beauty of their dreams.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote:
+          'Do not wait for the perfect moment, take the moment and make it perfect.',
+        kind: QuoteKind.Opinion,
+      },
+      {
+        quote: 'The only source of knowledge is experience.',
+        kind: QuoteKind.Opinion,
+      },
+
+      // Facts
+      {
+        quote: 'Honey never spoils and can last thousands of years.',
+        kind: QuoteKind.Fact,
+      },
+      {
+        quote: 'Bananas are berries, but strawberries are not.',
+        kind: QuoteKind.Fact,
+      },
+      { quote: 'Octopuses have three hearts.', kind: QuoteKind.Fact },
+      {
+        quote: "A group of flamingos is called a 'flamboyance'.",
+        kind: QuoteKind.Fact,
+      },
+      {
+        quote: 'Humans share 60% of their DNA with bananas.',
+        kind: QuoteKind.Fact,
+      },
+      {
+        quote: 'The Eiffel Tower can be 15 cm taller during hot days.',
+        kind: QuoteKind.Fact,
+      },
+      { quote: 'Wombat poop is cube-shaped.', kind: QuoteKind.Fact },
+      {
+        quote:
+          'Some metals are so reactive that they explode on contact with water.',
+        kind: QuoteKind.Fact,
+      },
+      {
+        quote:
+          'There are more stars in the universe than grains of sand on Earth.',
+        kind: QuoteKind.Fact,
+      },
+      {
+        quote: 'Venus is the only planet that spins clockwise.',
+        kind: QuoteKind.Fact,
+      },
+    ],
+  })
+
+  console.timeEnd('Seeding complete 🌱')
+}
+
+main()
+  .then(() => {
+    console.log('Process completed')
+  })
+  .catch((e) => console.log(e))

--- a/generator-prisma-client/esbuild-cjs/src/db.ts
+++ b/generator-prisma-client/esbuild-cjs/src/db.ts
@@ -1,0 +1,19 @@
+import process from 'node:process'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { PrismaClient } from './generated/prisma/client'
+
+export type { PrismaClient } from './generated/prisma/client'
+
+export type GetDbParams = {
+  connectionString: string
+}
+
+export function getDb({ connectionString }: GetDbParams) {
+  const pool = new PrismaPg({ connectionString })
+  const prisma = new PrismaClient({ adapter: pool })
+
+  return prisma
+}
+
+const prisma = getDb({ connectionString: process.env.DIRECT_URL! })
+export default prisma

--- a/generator-prisma-client/esbuild-cjs/src/hono.ts
+++ b/generator-prisma-client/esbuild-cjs/src/hono.ts
@@ -1,0 +1,45 @@
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+import 'dotenv/config'
+import prisma, { type PrismaClient } from './db'
+
+const app = new Hono<{
+  Variables: {
+    db: PrismaClient,
+  },
+}>()
+
+app.use('*', async (c, next) => {
+  c.set('db', prisma)
+  await next()
+})
+
+app.get('/quotes', async (c) => {
+  const db = c.get('db')
+  const quotes = await db.quotes.findMany({ take: 2 })
+  return c.json(quotes)
+})
+
+const port = 3000
+console.log(`Server is running on http://localhost:${port}`)
+
+const server = serve({
+  fetch: app.fetch,
+  port,
+})
+
+// graceful shutdown
+process.on('SIGINT', () => {
+  server.close()
+  process.exit(0)
+})
+
+process.on('SIGTERM', () => {
+  server.close((err) => {
+    if (err) {
+      console.error(err)
+      process.exit(1)
+    }
+    process.exit(0)
+  })
+})

--- a/generator-prisma-client/esbuild-cjs/src/minimal.ts
+++ b/generator-prisma-client/esbuild-cjs/src/minimal.ts
@@ -1,0 +1,8 @@
+import prisma from './db'
+
+async function main() {
+  const quotes = await prisma.quotes.findMany({ take: 2 })
+  console.log(quotes)
+}
+
+main()

--- a/generator-prisma-client/esbuild-cjs/src/prisma-enums.ts
+++ b/generator-prisma-client/esbuild-cjs/src/prisma-enums.ts
@@ -1,0 +1,1 @@
+export * from './generated/prisma/enums'

--- a/generator-prisma-client/esbuild-cjs/tsconfig.json
+++ b/generator-prisma-client/esbuild-cjs/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "node18",
+    "target": "es2022",
+    "moduleResolution": "node16",
+    "sourceMap": true,
+    "outDir": "dist",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
This PR adds new starter demo project `generator-prisma-client/esbuild-cjs` using Prisma Postgres + the new ESM-compatible `prisma-client` generator.

- **Framework**: Hono
- **Bundler**: ESBuild
- **Runtime**: Node.js
- **Ticket**: [ORM-1185](https://linear.app/prisma-company/issue/ORM-1185/provide-demo-example-of-prisma-client-cjs-esbuild)
- Worked out of the box: No.