### PR TITLE
Remove runtime option from generator block from schema.prisma README.md

### DIFF
--- a/generator-prisma-client/nextjs-starter-webpack/README.md
+++ b/generator-prisma-client/nextjs-starter-webpack/README.md
@@ -28,7 +28,6 @@ To successfully run the project, you will need the following:
     provider = "prisma-client"
     output = "../lib/generated/prisma"
     previewFeatures = ["driverAdapters", "queryCompiler"]
-    runtime = "nodejs"
   }
   ```
 


### PR DESCRIPTION
Remove `runtime` from generator block from `schema.prisma` README.md