### PR TITLE
Nuxt: Run `build` during CI tests

### DIFF
--- a/.github/tests/orm/nuxt/run.sh
+++ b/.github/tests/orm/nuxt/run.sh
@@ -60,7 +60,24 @@ npx prisma db seed
 echo "🧪 Starting Nuxt app..."
 npm run dev &
 pid=$!
+sleep 15
 
+# Check frontend
+echo "🔎 Checking http://localhost:3000/"
+curl --fail 'http://localhost:3000/'
+
+# Cleanup
+echo "🛑 Shutting down Nuxt app (PID $pid)"
+kill "$pid"
+
+# Build the app
+echo "🔨 Building Nuxt app..."
+npm run build
+
+# Start the production build
+echo "🚀 Starting production build..."
+npm run start
+pid=$!
 sleep 15
 
 # Check frontend


### PR DESCRIPTION
Runs also the `build` step during CI. This is not working for me at the moment and results in
```
[nitro 12:15:20]  ERROR  TypeError [ERR_INVALID_MODULE_SPECIFIER]: Invalid module ".prisma" is not a valid package name imported from D:\Programming\prisma-examples\orm\nuxt\node_modules\@prisma\client\default.js
```

(tracked at https://github.com/prisma/prisma/issues/27274) 