### PR TITLE
Nuxt, generator-prisma-client: Use experimental wasm mode of nitro

### DIFF
--- a/generator-prisma-client/nuxt3-starter-nodejs/nuxt.config.ts
+++ b/generator-prisma-client/nuxt3-starter-nodejs/nuxt.config.ts
@@ -3,5 +3,10 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-05-15',
   devtools: { enabled: true },
   modules: ['@nuxtjs/tailwindcss'],
-  css: ['~/assets/css/main.css']
+  css: ['~/assets/css/main.css'],
+  nitro: {
+    experimental: {
+      wasm: true,
+    },
+  },
 })


### PR DESCRIPTION
`pnpm build` works but preview results in the same issue as https://github.com/prisma/prisma-examples/issues/8280. So it's likely that the wasm file is actually never processed by nitro.