### PR TITLE
fix(orm/typedsql): bump Prisma to 6.15.0 and refresh dev deps to resolve config type breakage

### DIFF
--- a/orm/typedsql/package.json
+++ b/orm/typedsql/package.json
@@ -16,11 +16,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@prisma/client": "6.9.0"
+    "@prisma/client": "6.15.0"
   },
   "devDependencies": {
-    "@types/node": "22.15.32",
-    "prisma": "6.9.0",
-    "tsx": "4.20.3"
+    "@types/node": "^24.3.0",
+    "dotenv": "^17.2.2",
+    "prisma": "6.15.0",
+    "tsx": "4.20.5"
   }
 }


### PR DESCRIPTION
## What’s in this PR

Updates the **orm/typedsql** example to the latest stable Prisma release to fix a TypeScript break caused by recent changes in Prisma’s config types.

### Changes
- `@prisma/client`: 6.9.0 ➜ 6.15.0  
- `prisma`: 6.9.0 ➜ 6.15.0  
- `@types/node`: 22.15.32 ➜ ^24.3.0  
- `tsx`: 4.20.3 ➜ 4.20.5 
- Add `dotenv` to dev dependencies to make local env loading explicit  

> Only `orm/typedsql/package.json` is touched. No source changes. 

### Why
Recent Prisma releases introduced updates around configuration typing, which caused the typedsql example to fail type-checking when following latest Prisma docs. Moving to **6.15.0** aligns the example with the current stable.

TypedSQL docs for reference: https://www.prisma.io/docs/orm/reference/prisma-config-reference

### Notes
- Keeps the example on the latest stable Prisma to reduce churn for new users trying TypedSQL.
- No behavioral changes expected; dependency maintenance only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated underlying dependencies to the latest stable releases to improve compatibility, security patches, and overall reliability.
  - Added environment variable tooling to streamline local development and configuration.
  - Improves build consistency and reduces setup friction for contributors.
  - No user-facing changes or behavior modifications in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->