### PR TITLE
docs: fix MongoDB example README link

### DIFF
--- a/databases/mongodb/README.md
+++ b/databases/mongodb/README.md
@@ -1,11 +1,11 @@
 # MongoDB example
 
-This example shows how to use Prisma with MongoDB and use [Prisma Client](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client) in a **Node.js script** to read and write data in a MongoDB database. You can find the database schema in [`./prisma/schema.prisma`](./schema.sql).
+This example shows how to use Prisma with MongoDB and use [Prisma Client](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client) in a **Node.js script** to read and write data in a MongoDB database. You can find the database schema in [`./prisma/schema.prisma`](./prisma/schema.prisma).
 
 The example consists of two parts:
 
 - `tests/prisma.test.ts`: Jest test (in TypeScript) with a variety of Prisma Client queries and assertions to showcase access patterns
-- `src/prisma-examples`: TypesScript files containing different Prisma Client queries
+- `src/prisma-examples`: TypeScript files containing different Prisma Client queries
 
 ## How to use
 


### PR DESCRIPTION
## Summary

Fixes two small README issues in the MongoDB example:

- updates the `./prisma/schema.prisma` link to point at the actual Prisma schema file
- fixes a `TypesScript` typo in the description of the example scripts

## Testing

- `git diff --check`
- `test -f databases/mongodb/prisma/schema.prisma`
- `! rg "schema.sql|TypesScript" databases/mongodb/README.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MongoDB Prisma examples README with corrected file path references and improved formatting consistency for TypeScript query example descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->