### PR TITLE
fix(compute): add Hono template entrypoint

### DIFF
--- a/compute/hono/prisma.compute.json
+++ b/compute/hono/prisma.compute.json
@@ -2,6 +2,7 @@
   "app": {
     "name": "prisma-compute-hono",
     "framework": "hono",
+    "entry": "src/index.ts",
     "httpPort": 8080
   }
 }

--- a/tests/compute.test.ts
+++ b/tests/compute.test.ts
@@ -79,19 +79,6 @@ describe('Prisma Compute examples', () => {
       expect(rootEntries.filter((entry) => lockfileNames.has(entry))).toEqual([
         'bun.lock',
       ])
-      const computeConfig = JSON.parse(
-        await readFile(
-          path.join(templateDirectory, 'prisma.compute.json'),
-          'utf8',
-        ),
-      ) as {
-        app?: {
-          entry?: string
-        }
-      }
-      if (template.framework === 'hono') {
-        expect(computeConfig.app?.entry).toBe(smokeRouteByFramework.get('hono'))
-      }
 
       const packageJson = JSON.parse(
         await readFile(path.join(templateDirectory, 'package.json'), 'utf8'),

--- a/tests/compute.test.ts
+++ b/tests/compute.test.ts
@@ -79,6 +79,19 @@ describe('Prisma Compute examples', () => {
       expect(rootEntries.filter((entry) => lockfileNames.has(entry))).toEqual([
         'bun.lock',
       ])
+      const computeConfig = JSON.parse(
+        await readFile(
+          path.join(templateDirectory, 'prisma.compute.json'),
+          'utf8',
+        ),
+      ) as {
+        app?: {
+          entry?: string
+        }
+      }
+      if (template.framework === 'hono') {
+        expect(computeConfig.app?.entry).toBe(smokeRouteByFramework.get('hono'))
+      }
 
       const packageJson = JSON.parse(
         await readFile(path.join(templateDirectory, 'package.json'), 'utf8'),


### PR DESCRIPTION
## Purpose of change

Make the Hono Prisma Compute template deployable by giving the Bun build strategy an explicit source entrypoint.

## What's changed and why

- Add `entry: "src/index.ts"` to `compute/hono/prisma.compute.json`. Without it, the template installs, applies its database schema, and compiles successfully, but artifact creation fails with `Entrypoint is required` because `package.json` has no `main` or `module` field.

## Testing notes / Before-after

- Before: `app build` failed after TypeScript compilation with `Entrypoint is required. Pass --entrypoint or define package.json main`.
- After: `app build --json --no-interactive` succeeds with build type `bun` and packaged entrypoint `index.js`.
- `npx vitest run tests/compute.test.ts`
- `npx tsc --noEmit`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db bun run build`
