### PR TITLE
fix(compute): use @prisma/cli@next commands that exist in the published Prisma 8 CLI

### DIFF
--- a/compute/README.md
+++ b/compute/README.md
@@ -1,7 +1,6 @@
 # Prisma Compute examples
 
-These examples show Prisma ORM apps deployed to Prisma Compute with the
-latest `@prisma/cli`.
+These examples show Prisma ORM apps deployed to Prisma Compute.
 
 | Example | Description |
 | --- | --- |
@@ -12,5 +11,8 @@ latest `@prisma/cli`.
 Each example includes Prisma ORM, a PostgreSQL schema, seed data, and scripts for
 local development and Prisma Compute deployment.
 
-The Compute scripts call `bunx @prisma/cli@latest` directly, so the examples do
-not pin or install the Prisma CLI.
+The Compute scripts call `bunx @prisma/cli@next` directly, so the examples do
+not pin or install the Prisma CLI. They use `@next` because Prisma 8 is in
+release candidate and the `latest` npm tag still points at an old pre-release
+line. When Prisma 8 reaches general availability, the `@next` references will
+switch to `@latest`.

--- a/compute/README.md
+++ b/compute/README.md
@@ -12,7 +12,7 @@ Each example includes Prisma ORM, a PostgreSQL schema, seed data, and scripts fo
 local development and Prisma Compute deployment.
 
 The Compute scripts call `bunx @prisma/cli@next` directly, so the examples do
-not pin or install the Prisma CLI. They use `@next` because Prisma 8 is in
-release candidate and the `latest` npm tag still points at an old pre-release
-line. When Prisma 8 reaches general availability, the `@next` references will
-switch to `@latest`.
+not pin or install the Prisma CLI. They use `@next` because these examples
+target the Prisma 8 release candidate, while the `latest` npm tag still points
+at the earlier 3.x beta CLI with a different command set. When Prisma 8 reaches
+general availability, the `@next` references will switch to `@latest`.

--- a/compute/hono/README.md
+++ b/compute/hono/README.md
@@ -1,7 +1,7 @@
 # Prisma Compute Hono example
 
 This is a small Hono API that uses Prisma ORM with PostgreSQL and deploys to
-Prisma Compute with the latest `@prisma/cli`.
+Prisma Compute with `@prisma/cli@next` (Prisma 8 release candidate).
 
 ## Run locally
 
@@ -26,16 +26,22 @@ available at [http://localhost:8080/api/users](http://localhost:8080/api/users).
 
 ## Deploy to Prisma Compute
 
-Deploy the app. The script passes `.env` to Prisma Compute, so the deployed app
-uses the same seeded database.
+Connect this repository to a Prisma Compute project. Every push to the
+connected branch then builds and deploys automatically.
 
 ```bash
-bun run compute:deploy
+bun run compute:connect
 ```
 
-After a successful deploy, inspect the app with:
+After connecting, open the running service with:
 
 ```bash
 bun run compute:open
-bun run compute:logs
+```
+
+Each push creates a build. To stream the full build log, copy the build ID
+from the GitHub check run and run:
+
+```bash
+npx -y @prisma/cli@next build logs <build-id>
 ```

--- a/compute/hono/package.json
+++ b/compute/hono/package.json
@@ -10,11 +10,10 @@
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:seed": "prisma db seed",
-    "compute:login": "bunx @prisma/cli@latest auth login",
-    "compute:database:create": "bunx @prisma/cli@latest database create prisma-compute-hono --branch main",
-    "compute:deploy": "bunx @prisma/cli@latest app deploy --env .env",
-    "compute:open": "bunx @prisma/cli@latest app open",
-    "compute:logs": "bunx @prisma/cli@latest app logs"
+    "compute:login": "bunx @prisma/cli@next auth login",
+    "compute:database:create": "bunx @prisma/cli@next postgres create prisma-compute-hono --branch main",
+    "compute:connect": "bunx @prisma/cli@next git connect",
+    "compute:open": "bunx @prisma/cli@next service open"
   },
   "dependencies": {
     "@hono/node-server": "2.0.4",

--- a/compute/nextjs/README.md
+++ b/compute/nextjs/README.md
@@ -1,7 +1,7 @@
 # Prisma Compute Next.js example
 
 This is a Next.js App Router app that uses Prisma ORM with PostgreSQL and
-deploys to Prisma Compute with the latest `@prisma/cli`.
+deploys to Prisma Compute with `@prisma/cli@next` (Prisma 8 release candidate).
 
 The app sets `output: "standalone"` in `next.config.ts`, which is the output
 shape Prisma Compute expects for Next.js.
@@ -29,16 +29,22 @@ available at [http://localhost:3000/api/users](http://localhost:3000/api/users).
 
 ## Deploy to Prisma Compute
 
-Deploy the app. The script passes `.env` to Prisma Compute, so the deployed app
-uses the same seeded database.
+Connect this repository to a Prisma Compute project. Every push to the
+connected branch then builds and deploys automatically.
 
 ```bash
-bun run compute:deploy
+bun run compute:connect
 ```
 
-After a successful deploy, inspect the app with:
+After connecting, open the running service with:
 
 ```bash
 bun run compute:open
-bun run compute:logs
+```
+
+Each push creates a build. To stream the full build log, copy the build ID
+from the GitHub check run and run:
+
+```bash
+npx -y @prisma/cli@next build logs <build-id>
 ```

--- a/compute/nextjs/package.json
+++ b/compute/nextjs/package.json
@@ -10,11 +10,10 @@
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:seed": "prisma db seed",
-    "compute:login": "bunx @prisma/cli@latest auth login",
-    "compute:database:create": "bunx @prisma/cli@latest database create prisma-compute-nextjs --branch main",
-    "compute:deploy": "bunx @prisma/cli@latest app deploy --env .env",
-    "compute:open": "bunx @prisma/cli@latest app open",
-    "compute:logs": "bunx @prisma/cli@latest app logs"
+    "compute:login": "bunx @prisma/cli@next auth login",
+    "compute:database:create": "bunx @prisma/cli@next postgres create prisma-compute-nextjs --branch main",
+    "compute:connect": "bunx @prisma/cli@next git connect",
+    "compute:open": "bunx @prisma/cli@next service open"
   },
   "dependencies": {
     "@prisma/adapter-pg": "7.8.0",

--- a/compute/tanstack-start/README.md
+++ b/compute/tanstack-start/README.md
@@ -1,7 +1,7 @@
 # Prisma Compute TanStack Start example
 
 This is a TanStack Start app that uses Prisma ORM with PostgreSQL and deploys to
-Prisma Compute with the latest `@prisma/cli`.
+Prisma Compute with `@prisma/cli@next` (Prisma 8 release candidate).
 
 The app uses the Nitro Vite plugin so `vite build` emits the `.output/server`
 shape supported by Prisma Compute.
@@ -29,16 +29,22 @@ available at [http://localhost:3000/api/users](http://localhost:3000/api/users).
 
 ## Deploy to Prisma Compute
 
-Deploy the app. The script passes `.env` to Prisma Compute, so the deployed app
-uses the same seeded database.
+Connect this repository to a Prisma Compute project. Every push to the
+connected branch then builds and deploys automatically.
 
 ```bash
-bun run compute:deploy
+bun run compute:connect
 ```
 
-After a successful deploy, inspect the app with:
+After connecting, open the running service with:
 
 ```bash
 bun run compute:open
-bun run compute:logs
+```
+
+Each push creates a build. To stream the full build log, copy the build ID
+from the GitHub check run and run:
+
+```bash
+npx -y @prisma/cli@next build logs <build-id>
 ```

--- a/compute/tanstack-start/package.json
+++ b/compute/tanstack-start/package.json
@@ -13,11 +13,10 @@
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:seed": "prisma db seed",
-    "compute:login": "bunx @prisma/cli@latest auth login",
-    "compute:database:create": "bunx @prisma/cli@latest database create prisma-compute-tanstack-start --branch main",
-    "compute:deploy": "bunx @prisma/cli@latest app deploy --env .env",
-    "compute:open": "bunx @prisma/cli@latest app open",
-    "compute:logs": "bunx @prisma/cli@latest app logs"
+    "compute:login": "bunx @prisma/cli@next auth login",
+    "compute:database:create": "bunx @prisma/cli@next postgres create prisma-compute-tanstack-start --branch main",
+    "compute:connect": "bunx @prisma/cli@next git connect",
+    "compute:open": "bunx @prisma/cli@next service open"
   },
   "dependencies": {
     "@prisma/adapter-pg": "7.8.0",

--- a/tests/compute.test.ts
+++ b/tests/compute.test.ts
@@ -91,9 +91,9 @@ describe('Prisma Compute examples', () => {
       const computeScripts = Object.entries(packageJson.scripts ?? {}).filter(
         ([name]) => name.startsWith('compute:'),
       )
-      expect(computeScripts).toHaveLength(5)
+      expect(computeScripts).toHaveLength(4)
       for (const [, command] of computeScripts) {
-        expect(command).toMatch(/^bunx @prisma\/cli@latest /)
+        expect(command).toMatch(/^bunx @prisma\/cli@next /)
       }
 
       await execa(


### PR DESCRIPTION
## What was broken

`@prisma/cli@latest` on npm resolves to **3.0.0-beta.30**, an abandoned 2021 pre-release. The command groups `app` and `database` that the Compute scripts relied on do not exist in Prisma 8 (`8.0.0-rc.1`).

## Command mapping

| Old (broken) | New (`8.0.0-rc.1`) |
|---|---|
| `bunx @prisma/cli@latest` | `bunx @prisma/cli@next` |
| `database create <name> --branch main` | `postgres create <name> --branch main` |
| `app deploy --env .env` (`compute:deploy` script) | `git connect` → renamed to `compute:connect`; every push to the connected branch builds and deploys automatically |
| `app open` | `service open` |
| `app logs` | removed; build logs are available via `npx -y @prisma/cli@next build logs <build-id>` from the GitHub check run |

## When to flip back to `@latest`

When Prisma 8 reaches general availability, replace all `@prisma/cli@next` references with `@prisma/cli@latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Compute examples for the Prisma 8 release candidate using `@prisma/cli@next`.
  - Documented repository connections and automatic deployments on pushes.
  - Added instructions for opening services and retrieving build logs with a build ID.
  - Removed outdated manual deployment, environment upload, and direct log commands.
  - Clarified current CLI release-channel availability.

- **Chores**
  - Updated example scripts for PostgreSQL creation and Git-based deployments.
  - Removed obsolete deployment and logging scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->