### PR TITLE
fix(compute): enable Prisma contract tooling

### DIFF
--- a/compute/hono/src/prisma/contract.prisma
+++ b/compute/hono/src/prisma/contract.prisma
@@ -1,3 +1,5 @@
+// use prisma-next
+
 model User {
   id        Int      @id @default(autoincrement())
   email     String   @unique

--- a/compute/nextjs/src/prisma/contract.prisma
+++ b/compute/nextjs/src/prisma/contract.prisma
@@ -1,3 +1,5 @@
+// use prisma-next
+
 model User {
   id        Int      @id @default(autoincrement())
   email     String   @unique

--- a/compute/tanstack-start/src/prisma/contract.prisma
+++ b/compute/tanstack-start/src/prisma/contract.prisma
@@ -1,3 +1,5 @@
+// use prisma-next
+
 model User {
   id        Int      @id @default(autoincrement())
   email     String   @unique


### PR DESCRIPTION
## Purpose

Make the Prisma editor recognize `contract.prisma` files in the official Compute database templates.

## Changes

- Add `// use prisma-next` as the first line of the Hono contract.
- Add the same directive to the Next.js contract.
- Add the same directive to the TanStack Start contract.

## Testing

- `bun run test -- tests/compute.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Prisma schema guidance for using the `prisma-next` workflow across supported application templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->