### PR TITLE
Point repo links at prisma/orm

### DIFF
--- a/databases/postgresql-supabase/prisma/seed.ts
+++ b/databases/postgresql-supabase/prisma/seed.ts
@@ -42,7 +42,7 @@ const userData = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
         },
         {

--- a/orm/astro/README.md
+++ b/orm/astro/README.md
@@ -73,4 +73,4 @@ If you want to try this example with another database rather than Prisma Postgre
 
 - Check out the [Prisma docs](https://www.prisma.io/docs)
 - Share your feedback on the [Prisma Discord](https://pris.ly/discord/)
-- Create issues and ask questions on [GitHub](https://github.com/prisma/prisma/)
+- Create issues and ask questions on [GitHub](https://github.com/prisma/orm/)

--- a/orm/cloudflare-workers/README.md
+++ b/orm/cloudflare-workers/README.md
@@ -99,4 +99,4 @@ curl -X DELETE http://localhost:8788/users/1
 
 - Check out the [Prisma docs](https://www.prisma.io/docs)
 - Share your feedback on the [Prisma Discord](https://pris.ly/discord/)
-- Create issues and ask questions on [GitHub](https://github.com/prisma/prisma/)
+- Create issues and ask questions on [GitHub](https://github.com/prisma/orm/)

--- a/orm/express/prisma/seed.ts
+++ b/orm/express/prisma/seed.ts
@@ -38,7 +38,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
         },
         {

--- a/orm/fastify-graphql-sdl-first/prisma/seed.ts
+++ b/orm/fastify-graphql-sdl-first/prisma/seed.ts
@@ -39,7 +39,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
           viewCount: 128,
         },

--- a/orm/fastify-graphql/prisma/seed.ts
+++ b/orm/fastify-graphql/prisma/seed.ts
@@ -39,7 +39,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
           viewCount: 128,
         },

--- a/orm/fastify/prisma/seed.ts
+++ b/orm/fastify/prisma/seed.ts
@@ -38,7 +38,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
         },
         {

--- a/orm/graphql-auth/prisma/seed.ts
+++ b/orm/graphql-auth/prisma/seed.ts
@@ -42,7 +42,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
           viewCount: 128,
         },

--- a/orm/graphql-gqloom/prisma/seed.ts
+++ b/orm/graphql-gqloom/prisma/seed.ts
@@ -36,7 +36,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
           viewCount: 128,
         },

--- a/orm/graphql-gqloom/src/resolvers/post.ts
+++ b/orm/graphql-gqloom/src/resolvers/post.ts
@@ -125,7 +125,7 @@ export const postResolver = resolver.of(Post, {
       id: z.number().int(),
     })
     .resolve(async ({ id }) => {
-      // TODO: Simplify once https://github.com/prisma/prisma/issues/16715 is fixed
+      // TODO: Simplify once https://github.com/prisma/orm/issues/16715 is fixed
       const postPublished = await prisma.post.findUnique({
         where: { id },
         select: { published: true },

--- a/orm/graphql-nexus/prisma/seed.ts
+++ b/orm/graphql-nexus/prisma/seed.ts
@@ -39,7 +39,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
           viewCount: 128,
         },

--- a/orm/graphql-sdl-first/prisma/seed.ts
+++ b/orm/graphql-sdl-first/prisma/seed.ts
@@ -39,7 +39,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
           viewCount: 128,
         },

--- a/orm/graphql-subscriptions/prisma/seed.ts
+++ b/orm/graphql-subscriptions/prisma/seed.ts
@@ -38,7 +38,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
         },
         {

--- a/orm/graphql/prisma/seed.ts
+++ b/orm/graphql/prisma/seed.ts
@@ -39,7 +39,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
           viewCount: 128,
         },

--- a/orm/graphql/src/schema/post.ts
+++ b/orm/graphql/src/schema/post.ts
@@ -139,7 +139,7 @@ builder.mutationFields((t) => ({
       id: t.arg.int({ required: true }),
     },
     resolve: async (query, parent, args) => {
-      // Toggling become simpler once this bug is resolved: https://github.com/prisma/prisma/issues/16715
+      // Toggling become simpler once this bug is resolved: https://github.com/prisma/orm/issues/16715
       const postPublished = await prisma.post.findUnique({
         where: { id: args.id },
         select: { published: true },

--- a/orm/grpc/prisma/seed.ts
+++ b/orm/grpc/prisma/seed.ts
@@ -38,7 +38,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
         },
         {

--- a/orm/hapi-graphql-sdl-first/prisma/seed.ts
+++ b/orm/hapi-graphql-sdl-first/prisma/seed.ts
@@ -39,7 +39,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
           viewCount: 128,
         },

--- a/orm/hapi-graphql/prisma/seed.ts
+++ b/orm/hapi-graphql/prisma/seed.ts
@@ -39,7 +39,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
           viewCount: 128,
         },

--- a/orm/hapi/prisma/seed.ts
+++ b/orm/hapi/prisma/seed.ts
@@ -38,7 +38,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
         },
         {

--- a/orm/hono/README.md
+++ b/orm/hono/README.md
@@ -71,4 +71,4 @@ If you want to try this example with another database, refer to the [Databases](
 
 - Check out the [Prisma docs](https://www.prisma.io/docs)
 - Share feedback on the [Prisma Discord](https://pris.ly/discord/)
-- Create issues or ask questions on [GitHub](https://github.com/prisma/prisma/)
+- Create issues or ask questions on [GitHub](https://github.com/prisma/orm/)

--- a/orm/hono/prisma/seed.ts
+++ b/orm/hono/prisma/seed.ts
@@ -38,7 +38,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
         },
         {

--- a/orm/koa/prisma/seed.ts
+++ b/orm/koa/prisma/seed.ts
@@ -38,7 +38,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
         },
         {

--- a/orm/nest-graphql-sdl-first/prisma/seed.ts
+++ b/orm/nest-graphql-sdl-first/prisma/seed.ts
@@ -39,7 +39,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
           viewCount: 128,
         },

--- a/orm/nest-graphql/prisma/seed.ts
+++ b/orm/nest-graphql/prisma/seed.ts
@@ -39,7 +39,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
           viewCount: 128,
         },

--- a/orm/nest/prisma/seed.ts
+++ b/orm/nest/prisma/seed.ts
@@ -38,7 +38,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
         },
         {

--- a/orm/nextjs-graphql/prisma/seed.ts
+++ b/orm/nextjs-graphql/prisma/seed.ts
@@ -38,7 +38,7 @@ const userData: Prisma.UserCreateInput[] = [
       create: [
         {
           title: "Ask a question about Prisma on GitHub",
-          content: "https://www.github.com/prisma/prisma/discussions",
+          content: "https://www.github.com/prisma/orm/discussions",
           published: true,
         },
         {

--- a/orm/nuxt-prisma-module/prisma/seed.ts
+++ b/orm/nuxt-prisma-module/prisma/seed.ts
@@ -34,7 +34,7 @@ const userData = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
         },
         {

--- a/orm/nuxt/prisma/seed.ts
+++ b/orm/nuxt/prisma/seed.ts
@@ -40,7 +40,7 @@ const userData = [
       create: [
         {
           title: 'Ask a question about Prisma on GitHub',
-          content: 'https://www.github.com/prisma/prisma/discussions',
+          content: 'https://www.github.com/prisma/orm/discussions',
           published: true,
           viewCount: 128,
         },

--- a/orm/react-router-7/README.md
+++ b/orm/react-router-7/README.md
@@ -138,4 +138,4 @@ datasource db {
 
 - Check out the [Prisma docs](https://www.prisma.io/docs)
 - Share your feedback on the [Prisma Discord](https://pris.ly/discord/)
-- Create issues and ask questions on [GitHub](https://github.com/prisma/prisma/)
+- Create issues and ask questions on [GitHub](https://github.com/prisma/orm/)

--- a/orm/solid-start/README.md
+++ b/orm/solid-start/README.md
@@ -70,4 +70,4 @@ If you want to try this example with another database rather than Prisma Postgre
 
 - Check out the [Prisma docs](https://www.prisma.io/docs)
 - Share your feedback on the [Prisma Discord](https://pris.ly/discord/)
-- Create issues and ask questions on [GitHub](https://github.com/prisma/prisma/)
+- Create issues and ask questions on [GitHub](https://github.com/prisma/orm/)

--- a/orm/sveltekit/README.md
+++ b/orm/sveltekit/README.md
@@ -75,4 +75,4 @@ If you want to try this example with another database rather than Prisma Postgre
 
 - Check out the [Prisma docs](https://www.prisma.io/docs)
 - Share your feedback on the [Prisma Discord](https://pris.ly/discord/)
-- Create issues and ask questions on [GitHub](https://github.com/prisma/prisma/)
+- Create issues and ask questions on [GitHub](https://github.com/prisma/orm/)


### PR DESCRIPTION
Follow-up to #8597: rewrites the remaining 31 `github.com/prisma/prisma` links (seed-file header comments and READMEs) to `github.com/prisma/orm`, the repository's name since the rename. Pure link rewrite, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project links and “Next steps” references to point to the current Prisma ORM repository.
  - Corrected issue and discussion links across example applications and guides.

- **Bug Fixes**
  - Updated seeded discussion URLs so generated example content links to the correct repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->